### PR TITLE
Isolate bad revisions

### DIFF
--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 
-AWS_CREDS="-v /Users/pwagner/.aws/credentials:/root/.aws/credentials "
+AWS_CREDS="-v ${HOME}/.aws/credentials:/root/.aws/credentials "
 # -e AWS_ACCESS_KEY_ID= -e AWS_SECRET_ACCESS_KEY= would also work
 
 FLOTILLA="pwagner/flotilla"
-REGIONS="-r us-east-1 -r us-west-2"
+REGIONS="-r us-east-1"
+# -r us-east-1 -r us-west-2 would also work
 
 # Update:
 docker pull ${FLOTILLA}
 
 # Initialize environment:
-#docker run ${AWS_CREDS} ${FLOTILLA} init ${REGIONS} --domain mycloudand.me
+docker run ${AWS_CREDS} ${FLOTILLA} init ${REGIONS} --domain mycloudand.me
 
 # Create user(s):
 docker run ${AWS_CREDS} ${FLOTILLA} user ${REGIONS} --name pwagner --ssh-key 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0b/hxxZesuGbCH7DBn299BZSwcviBFyPPpSm1+5ygO0j1qKoekt4Ou4PfHqBQtXuxyEKTPW1TXhUV764nwgUlPA0qs4tHB7NcKBiFCMr6I2RBohhiYk1Ed3XvvOR4W9Q3KrueBScXMLYBU0aKNpViR5i7WStkPsIemgE8uh73sDNPKRfzAuKz53qbqaqtEwPP8l25e85LfrCNOf4mBGTb1EO3GQccgXlbnOa3UDM1iQLRk/1bcSQN7ezrppGuvDkg4p73w+go34ZWCRUzWUcro0ZYUjty+GMzq6Chv8rdqc2MoCzuUZ356Nq3F0sbFVclGPNkEt46whyMDG43YY6j'
@@ -19,7 +20,7 @@ docker run ${AWS_CREDS} ${FLOTILLA} user ${REGIONS} --name pwagner --ssh-key 'ss
 docker run ${AWS_CREDS} ${FLOTILLA} region ${REGIONS} --admin pwagner
 
 # Add a service:
-docker run ${AWS_CREDS} ${FLOTILLA} service ${REGIONS} --name elasticsearch --public-ports 9200-http --private-ports 9300-tcp --health-check HTTP:9200/
+docker run ${AWS_CREDS} ${FLOTILLA} service ${REGIONS} --name elasticsearch --public-ports 9200-http --private-ports 9300-tcp --health-check HTTP:9200/ --instance-min 2 --instance-max 3
 
 # Add a revision of that service:
 tar -cf - elasticsearch.env | docker run -i ${AWS_CREDS} ${FLOTILLA} revision ${REGIONS} --name elasticsearch --label initial

--- a/demo/elasticsearch.env
+++ b/demo/elasticsearch.env
@@ -1,4 +1,4 @@
-DOCKER_IMAGE=elasticsearch
+DOCKER_IMAGE=pwagner/elasticsearch-aws
 DOCKER_PORT_9200=9200
 DOCKER_PORT_9300=9300
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,12 @@
 boto==2.38.0
+boto3==1.2.3
+botocore==1.3.23
 click==6.2
+docutils==0.12
+jmespath==0.9.0
+python-dateutil==2.4.2
 git+https://github.com/thepwagner/python-systemd.git
 more-itertools==2.2
 pycrypto==2.6.1
+six==1.10.0
 wheel==0.24.0

--- a/src/cloudformation/scheduler.template
+++ b/src/cloudformation/scheduler.template
@@ -261,7 +261,10 @@
                     "route53:ChangeResourceRecordSets",
                     "route53:GetChange",
                     "route53:ListHostedZones",
-                    "route53:ListResourceRecordSets"
+                    "route53:ListResourceRecordSets",
+                    "sqs:CreateQueue",
+                    "sqs:DeleteQueue",
+                    "sqs:ListQueues"
                   ],
                   "Resource": "*"
                 }
@@ -357,6 +360,7 @@
                 {
                   "Effect": "Allow",
                   "Action": [
+                    "dynamodb:BatchWriteItem",
                     "dynamodb:GetItem",
                     "dynamodb:Scan"
                   ],

--- a/src/cloudformation/service-elb.template
+++ b/src/cloudformation/service-elb.template
@@ -649,6 +649,9 @@
   "Outputs": {
     "InstanceSg": {
       "Value": {"Ref": "InstanceSg"}
+    },
+    "Elb": {
+      "Value": {"Ref": "Elb"}
     }
   }
 }

--- a/src/cloudformation/service-elb.template
+++ b/src/cloudformation/service-elb.template
@@ -647,9 +647,6 @@
     }
   },
   "Outputs": {
-    "InstanceSg": {
-      "Value": {"Ref": "InstanceSg"}
-    },
     "Elb": {
       "Value": {"Ref": "Elb"}
     }

--- a/src/cloudformation/service-elb.template
+++ b/src/cloudformation/service-elb.template
@@ -438,6 +438,43 @@
               },
               {"Ref": "AWS::NoValue"}
             ]
+          },
+          {
+            "PolicyName": "FlotillaQueue",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "sqs:GetQueueUrl",
+                    "sqs:SendMessage"
+                  ],
+                  "Resource": {
+                    "Fn::Join": [
+                      "", [
+                        "arn:aws:sqs:",
+                        {"Ref": "AWS::Region"},
+                        ":",
+                        {"Ref": "AWS::AccountId"},
+                        ":flotilla-",
+                        {"Ref": "FlotillaEnvironment"},
+                        "-scheduler"
+                      ]
+                    ]
+                  }
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "sqs:DeleteMessage",
+                    "sqs:GetQueueUrl",
+                    "sqs:ReceiveMessage",
+                    "sqs:SendMessage"
+                  ],
+                  "Resource": {"Fn::GetAtt": ["ServiceMessageQueue", "Arn"]}
+                }
+              ]
+            }
           }
         ],
         "Path": "/"
@@ -643,6 +680,21 @@
             }
           }
         ]
+      }
+    },
+    "ServiceMessageQueue": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {
+        "QueueName": {
+          "Fn::Join": [
+            "-", [
+              "flotilla",
+              {"Ref": "FlotillaEnvironment"},
+              "service",
+              {"Ref": "ServiceName"}
+            ]
+          ]
+        }
       }
     }
   },

--- a/src/cloudformation/service-elb.template
+++ b/src/cloudformation/service-elb.template
@@ -219,7 +219,7 @@
                 {
                   "Effect": "Allow",
                   "Action": [
-                    "dynamodb:GetItem"
+                    "dynamodb:BatchGetItem"
                   ],
                   "Resource": {
                     "Fn::Join": [
@@ -279,7 +279,7 @@
                 {
                   "Effect": "Allow",
                   "Action": [
-                    "dynamodb:GetItem"
+                    "dynamodb:BatchGetItem"
                   ],
                   "Resource": {
                     "Fn::Join": [
@@ -591,10 +591,10 @@
         ],
         "HealthCheck": {
           "HealthyThreshold": "2",
-          "Interval": "6",
+          "Interval": "5",
           "Target": {"Ref": "HealthCheckTarget"},
-          "Timeout": "5",
-          "UnhealthyThreshold": "4"
+          "Timeout": "2",
+          "UnhealthyThreshold": "3"
         },
         "SecurityGroups": [
           {"Ref": "ElbSg"}

--- a/src/flotilla/agent/__init__.py
+++ b/src/flotilla/agent/__init__.py
@@ -1,4 +1,5 @@
 from .agent import FlotillaAgent
 from .db import FlotillaAgentDynamo
 from .elb import LoadBalancer
+from .messaging import FlotillaAgentMessaging
 from .systemd import SystemdUnits

--- a/src/flotilla/agent/agent.py
+++ b/src/flotilla/agent/agent.py
@@ -4,13 +4,15 @@ logger = logging.getLogger('flotilla')
 
 
 class FlotillaAgent(object):
-    def __init__(self, service, db, locks, systemd, elb):
+    def __init__(self, service, db, locks, systemd, messaging, elb):
         self._service = service
         self._db = db
         self._locks = locks
         self._systemd = systemd
+        self._messaging = messaging
         self._elb = elb
         self._assignments = []
+        self._first = True
 
     def assignment(self):
         """Check for active assignment and update if necessary."""
@@ -30,10 +32,19 @@ class FlotillaAgent(object):
 
                     if not self._elb or self._elb.register():
                         self._assignments = assignments
+                    else:
+                        for rev in assignments:
+                            self._messaging.service_failure(rev)
                 finally:
                     self._locks.release_lock(deploy_lock)
+                    # else: setup for a "lock released" callback
 
     def health(self):
         """Write health to systemd."""
         units_status = self._systemd.get_unit_status()
         self._db.store_status(units_status)
+
+        if self._first:  # Sucks to your CAS-mar
+            logger.info('Requesting reschedule.')
+            self._messaging.reschedule()
+            self._first = False

--- a/src/flotilla/agent/db.py
+++ b/src/flotilla/agent/db.py
@@ -1,9 +1,9 @@
 import logging
 import json
 import time
+from collections import defaultdict
 from flotilla.model import FlotillaServiceRevision, FlotillaUnit, \
-    GLOBAL_ASSIGNMENT
-from boto.dynamodb2.exceptions import ItemNotFound
+    GLOBAL_ASSIGNMENT, GLOBAL_ASSIGNMENT_SHARDS
 from Crypto.Cipher import AES
 
 logger = logging.getLogger('flotilla')
@@ -16,9 +16,9 @@ class FlotillaAgentDynamo(object):
     status
         -PutItem
     assignments:
-        - GetItem
+        - BatchGetItem
     revisions:
-        - GetItem
+        - BatchGetItem
     units:
         - BatchGetItem
     """
@@ -26,6 +26,8 @@ class FlotillaAgentDynamo(object):
     def __init__(self, instance_id, service_name, status_table,
                  assignments_table, revisions_table, units_table, kms):
         self._id = instance_id
+        global_shard = hash(instance_id) % GLOBAL_ASSIGNMENT_SHARDS
+        self._global_id = '%s_%d' % (GLOBAL_ASSIGNMENT, global_shard)
         self._service = service_name
         self._status = status_table
         self._assignments = assignments_table
@@ -46,33 +48,40 @@ class FlotillaAgentDynamo(object):
         self._status.put_item(data=data, overwrite=True)
         logger.debug('Stored status as %s.', self._id)
 
-    def get_units(self):
-        """Get currently assigned FlotillaUnits."""
+    def get_assignments(self):
+        assignments = self._assignments.batch_get([
+            {'instance_id': self._id}, {'instance_id': self._global_id}])
+
+        assigned_revisions = [assignment['assignment'] for assignment in
+                              assignments]
+        return sorted(assigned_revisions)
+
+    def get_units(self, assigned_revisions):
+        """
+        Get currently assigned FlotillaUnits.
+        :param assigned_revisions: Assigned revisions
+        :return: Revisions.
+        """
+
+        # Fetch every revision and index units:
+        revisions = {}
+        unit_revisions = defaultdict(list)
+        revision_keys = [{'rev_hash': assigned_revision}
+                         for assigned_revision in set(assigned_revisions)]
+        for revision_item in self._revisions.batch_get(revision_keys):
+            rev_hash = revision_item['rev_hash']
+            revision = FlotillaServiceRevision(label=revision_item['label'])
+            revisions[rev_hash] = revision
+            for unit in revision_item['units']:
+                unit_revisions[unit].append(rev_hash)
+
+        # Fetch every unit:
         units = []
-        assigned_revision = self.get_assignment()
-        if assigned_revision:
-            logger.debug('Assigned: %s, fetching units.', assigned_revision)
-            units += self._load_revision_units(assigned_revision)
-
-            logger.debug('Assignment %s contained %d units.', assigned_revision,
-                         len(units))
-
-        try:
-            global_assignment = self._assignments.get_item(
-                    instance_id=GLOBAL_ASSIGNMENT)
-            global_revision = global_assignment['assignment']
-            units += self._load_revision_units(global_revision)
-        except ItemNotFound:
-            pass
-        return units
-
-    def _load_revision_units(self, assigned_revision):
-        revision_item = self._revisions.get_item(rev_hash=assigned_revision)
-        unit_items = self._units.batch_get(keys=[
-            {'unit_hash': unit} for unit in revision_item['units']
-            ])
-        units = []
-        for unit_item in unit_items:
+        unit_keys = [{'unit_hash': unit_hash}
+                     for unit_hash in sorted(unit_revisions.keys())]
+        logger.debug('Fetching %d units for %d/%d revisions.', len(unit_keys),
+                     len(revisions), len(assigned_revisions))
+        for unit_item in self._units.batch_get(unit_keys):
             env_key = unit_item.get('environment_key')
             if env_key:
                 decrypted_key = self._kms.decrypt(env_key.decode('base64'))
@@ -89,20 +98,19 @@ class FlotillaAgentDynamo(object):
             if unit_hash != unit_item['unit_hash']:
                 logger.warn('Unit hash %s expected %s', unit_hash,
                             unit_item['unit_hash'])
-            units.append(unit)
+                unit_hash = unit_item['unit_hash']
 
-        revision = FlotillaServiceRevision(label=revision_item['label'],
-                                           units=units)
-        revision_hash = revision.revision_hash
-        if revision_hash != assigned_revision:
-            # FIXME: enforce?
-            logger.warn('Revision hash %s expected %s', revision_hash,
-                        assigned_revision)
+            for revision in unit_revisions[unit_hash]:
+                rev_unit = FlotillaUnit(unit_item['name'], unit_file,
+                                        unit_environment, rev_hash)
+                units.append(rev_unit)
+                revisions[revision].units.append(rev_unit)
+
+        # Verify each revision matches expected hash:
+        for expected_hash, revision in revisions.items():
+            revision_hash = revision.revision_hash
+            if revision_hash != expected_hash:
+                # FIXME: enforce?
+                logger.warn('Revision hash %s expected %s', revision_hash,
+                            expected_hash)
         return units
-
-    def get_assignment(self):
-        try:
-            assignment = self._assignments.get_item(instance_id=self._id)
-            return assignment['assignment']
-        except ItemNotFound:
-            return None

--- a/src/flotilla/agent/db.py
+++ b/src/flotilla/agent/db.py
@@ -39,13 +39,14 @@ class FlotillaAgentDynamo(object):
         """Store unit status.
         :param unit_status Unit statuses.
         """
-        logger.debug('Storing status as %s.', self._id)
+        logger.debug('Storing status as %s...', self._id)
         data = dict(unit_status)
         data['service'] = self._service
         data['instance_id'] = self._id
         data['status_time'] = time.time()
         self._status.put_item(data=data, overwrite=True)
-        logger.debug('Stored status as %s.', self._id)
+        logger.info('Stored status of %s units as %s.', len(unit_status),
+                    self._id)
 
     def get_assignments(self):
         assignments = self._assignments.batch_get([

--- a/src/flotilla/agent/db.py
+++ b/src/flotilla/agent/db.py
@@ -40,8 +40,7 @@ class FlotillaAgentDynamo(object):
         :param unit_status Unit statuses.
         """
         logger.debug('Storing status as %s.', self._id)
-        data = {name: json.dumps(status)
-                for name, status in unit_status.items()}
+        data = dict(unit_status)
         data['service'] = self._service
         data['instance_id'] = self._id
         data['status_time'] = time.time()

--- a/src/flotilla/agent/elb.py
+++ b/src/flotilla/agent/elb.py
@@ -40,7 +40,7 @@ class LoadBalancer(object):
         logger.debug('Unregistered from %s.', self._elb_name)
         return state
 
-    def register(self, timeout=300):
+    def register(self, timeout=120):
         """Register and wait for health checks
         :param timeout Max time to wait
         :return Boolean registration state.

--- a/src/flotilla/agent/messaging.py
+++ b/src/flotilla/agent/messaging.py
@@ -1,0 +1,57 @@
+import json
+import logging
+
+logger = logging.getLogger('flotilla')
+
+from flotilla.scheduler.messaging import MESSAGE_RESCHEDULE, \
+    MESSAGE_SERVICE_FAILURE
+
+MESSAGE_DEPLOY_LOCK_RELEASED = 'DeployLockReleased'
+
+
+class FlotillaAgentMessaging(object):
+    def __init__(self, service, instance_id, scheduler_q, service_q):
+        self._service = service
+        self._instance_id = instance_id
+        self._scheduler_q = scheduler_q
+        self._service_q = service_q
+
+    def reschedule(self):
+        message = json.dumps({
+            'type': MESSAGE_RESCHEDULE,
+            'service': self._service
+        })
+        self._scheduler_q.send_message(MessageBody=message)
+
+    def service_failure(self, target_rev):
+        message = json.dumps({
+            'type': MESSAGE_SERVICE_FAILURE,
+            'service': self._service,
+            'revision': target_rev,
+            'instance': self._instance_id
+        })
+        self._scheduler_q.send_message(MessageBody=message)
+
+    def deploy_lock_released(self):
+        message = json.dumps({
+            'type': MESSAGE_DEPLOY_LOCK_RELEASED
+        })
+
+        self._service_q.send_message(MessageBody=message)
+
+    def receive(self):
+        for msg in self._service_q.receive_messages(WaitTimeSeconds=20):
+            try:
+                payload = json.loads(msg.body)
+                msg_type = payload['type']
+            except:
+                logger.warn('Invalid message')
+                msg.delete()
+                continue
+
+            if msg_type == MESSAGE_DEPLOY_LOCK_RELEASED:
+                # FIXME: do stuff here
+                pass
+            else:
+                logger.warn('Unknown message: %s', msg_type)
+            msg.delete()

--- a/src/flotilla/agent/systemd.py
+++ b/src/flotilla/agent/systemd.py
@@ -80,7 +80,6 @@ class SystemdUnits(object):
                 env_path = os.path.join(self._env_dir, name)
                 if not os.path.exists(env_path):
                     logger.debug('Writing environment file: %s', env_path)
-                    # TODO: KMS decrypt
                     with open(env_path, 'w') as env_file:
                         for key, value in unit.environment.items():
                             env_file.write(key)

--- a/src/flotilla/cli/scheduler.py
+++ b/src/flotilla/cli/scheduler.py
@@ -2,17 +2,15 @@ import click
 import logging
 import boto.dynamodb2
 import boto3
-from botocore.exceptions import ClientError
 
 from main import get_instance_id
 from flotilla.cli.options import *
+from flotilla.cli.utils import get_queue
 from flotilla.db import DynamoDbTables, DynamoDbLocks
 from flotilla.scheduler import *
 from flotilla.thread import RepeatingFunc
 
 logger = logging.getLogger('flotilla')
-
-QUEUE_NOT_FOUND = 'AWS.SimpleQueueService.NonExistentQueue'
 
 
 @click.group()
@@ -77,18 +75,14 @@ def start_scheduler(environment, domain, regions, lock_interval, loop_interval,
 
         queue_name = 'flotilla-%s-scheduler' % environment
         sqs = boto3.resource('sqs', region)
-        try:
-            message_q = sqs.get_queue_by_name(QueueName=queue_name)
+        message_q = get_queue(sqs, queue_name)
+        if message_q:
             elb = boto3.client('elb', region)
             doctor = ServiceDoctor(db, elb)
             messaging = FlotillaSchedulerMessaging(message_q, schedule, doctor)
 
             funcs.append(RepeatingFunc('scheduler-message-%s' % region,
                                        messaging.receive, 0))
-        except ClientError as e:
-            error_code = e.response['Error'].get('Code')
-            if error_code == QUEUE_NOT_FOUND:
-                logger.info('Scheduler message queue not found.')
 
     # Start loops:
     map(RepeatingFunc.start, funcs)

--- a/src/flotilla/cli/scheduler.py
+++ b/src/flotilla/cli/scheduler.py
@@ -84,7 +84,7 @@ def start_scheduler(environment, domain, regions, lock_interval, loop_interval,
             messaging = FlotillaSchedulerMessaging(message_q, schedule, doctor)
 
             funcs.append(RepeatingFunc('scheduler-message-%s' % region,
-                                       messaging.receive, 20.1))
+                                       messaging.receive, 0))
         except ClientError as e:
             error_code = e.response['Error'].get('Code')
             if error_code == QUEUE_NOT_FOUND:

--- a/src/flotilla/cli/utils.py
+++ b/src/flotilla/cli/utils.py
@@ -1,0 +1,18 @@
+import logging
+from botocore.exceptions import ClientError
+
+QUEUE_NOT_FOUND = 'AWS.SimpleQueueService.NonExistentQueue'
+
+logger = logging.getLogger('flotilla')
+
+
+def get_queue(sqs, queue_name):
+    try:
+        return sqs.get_queue_by_name(QueueName=queue_name)
+    except ClientError as e:
+        error_code = e.response['Error'].get('Code')
+        if error_code != QUEUE_NOT_FOUND:
+            raise e
+
+        logger.info('Queue %s not found.', queue_name)
+        return None

--- a/src/flotilla/client/region_meta.py
+++ b/src/flotilla/client/region_meta.py
@@ -1,9 +1,7 @@
 import logging
 
-import boto.vpc
-import boto.dynamodb2
-from boto.dynamodb2.table import Table
-from boto.exception import BotoServerError
+import boto3
+from botocore.exceptions import ClientError
 
 logger = logging.getLogger('flotilla')
 
@@ -14,10 +12,13 @@ class RegionMetadata(object):
 
     def store_regions(self, regions, per_region, instance_type, coreos_channel,
                       coreos_version):
-        region_items = [self._create_region_item(region)
-                        for region in regions]
+        region_params = {region: self._region_params(region)
+                         for region in regions}
 
-        scheduler_regions = per_region and region_items or (region_items[0],)
+        scheduler_regions = region_params.values()
+        print scheduler_regions
+        if not per_region:
+            scheduler_regions = (region_params[regions[0]],)
         for scheduler_region in scheduler_regions:
             scheduler_region['scheduler'] = True
             scheduler_region['scheduler_instance_type'] = instance_type
@@ -25,38 +26,46 @@ class RegionMetadata(object):
             scheduler_region['scheduler_coreos_version'] = coreos_version
         logger.debug('Prepared %d region records', len(regions))
 
+        region_updates = {}
+        for region_name, region_param in region_params.items():
+            region_updates[region_name] = {
+                k: {'Value': v, 'Action': 'PUT'}
+                for k, v in region_param.items()}
+
         table_name = 'flotilla-%s-regions' % self._environment
         for region in regions:
-            dynamo = boto.dynamodb2.connect_to_region(region)
+            # Connect to dynamo in each region:
+            dynamo = boto3.resource('dynamodb', region)
+            region_table = dynamo.Table(table_name)
 
-            region_table = Table(table_name, connection=dynamo)
-            with region_table.batch_write() as batch:
-                for region_item in region_items:
-                    batch.put_item(region_item, overwrite=True)
+            # Store records:
+            for region_name, region_update in region_updates.items():
+                region_table.update_item(Key={'region_name': region_name},
+                                         AttributeUpdates=region_update)
         logger.debug('Stored %d region records', len(regions))
 
-        return {r['region_name']: r for r in region_items}
+        return region_params
 
     @staticmethod
-    def _create_region_item(region):
-        region_item = {
-            'region_name': region
-        }
+    def _region_params(region):
+        region_params = {}
 
-        vpc = boto.vpc.connect_to_region(region)
+        ec2 = boto3.client('ec2', region)
         try:
-            vpcs = vpc.get_all_vpcs()
+            vpcs = ec2.describe_vpcs()
+            vpc_id = vpcs['Vpcs'][0]['VpcId']
             invalid_az = region + '-zzz'
-            vpc.create_subnet(vpcs[0].id, '172.31.192.0/20',
-                              availability_zone=invalid_az)
-        except BotoServerError as e:
-            if 'Subnets can currently only be created in ' \
-               'the following availability zones' not in e.message:
+            ec2.create_subnet(VpcId=vpc_id, CidrBlock='172.31.192.0/20',
+                              AvailabilityZone=invalid_az)
+        except ClientError as e:
+            message = e.response['Error'].get('Message')
+            if not message or 'Subnets can currently only be created in ' \
+                              'the following availability zones' not in message:
                 raise e
-            message_split = e.message.split(region)
+            message_split = message.split(region)
             # Invalid region is echoed back, every mention after that is an AZ:
             azs = sorted([s[0] for s in message_split[2:]])
             for az_index in range(3):
                 az = az_index % len(azs)
-                region_item['az%d' % (az_index + 1)] = region + azs[az]
-        return region_item
+                region_params['az%d' % (az_index + 1)] = region + azs[az]
+        return region_params

--- a/src/flotilla/client/region_meta.py
+++ b/src/flotilla/client/region_meta.py
@@ -16,7 +16,6 @@ class RegionMetadata(object):
                          for region in regions}
 
         scheduler_regions = region_params.values()
-        print scheduler_regions
         if not per_region:
             scheduler_regions = (region_params[regions[0]],)
         for scheduler_region in scheduler_regions:

--- a/src/flotilla/db/lock.py
+++ b/src/flotilla/db/lock.py
@@ -70,3 +70,10 @@ class DynamoDbLocks(object):
                 logger.debug('Lock belongs to %s, unable to release', owner)
         except ItemNotFound:
             logger.debug('Lock %s not found to release', name)
+
+    def get_owner(self, name):
+        try:
+            lock_item = self._locks.get_item(lock_name=name, consistent=True)
+            return lock_item['owner'], float(lock_item['acquire_time'])
+        except ItemNotFound:
+            return None, None

--- a/src/flotilla/model.py
+++ b/src/flotilla/model.py
@@ -4,14 +4,17 @@ import time
 
 UNIT_PREFIX = 'flotilla-'
 GLOBAL_ASSIGNMENT = 'global'
+GLOBAL_ASSIGNMENT_SHARDS = 16
+
 
 class FlotillaUnit(object):
     """Systemd unit file and configuration (environment variables)."""
 
-    def __init__(self, name, unit_file, environment={}):
+    def __init__(self, name, unit_file, environment={}, rev_hash=None):
         self.name = name
         self.unit_file = unit_file
         self.environment = environment or {}
+        self.rev_hash = rev_hash
 
     def __str__(self):
         return 'Unit: %s' % self.name
@@ -29,7 +32,8 @@ class FlotillaUnit(object):
     @property
     def full_name(self):
         name, ext = os.path.splitext(self.name)
-        return '%s%s-%s%s' % (UNIT_PREFIX, name, self.unit_hash, ext)
+        hash = self.rev_hash or self.unit_hash
+        return '%s%s-%s%s' % (UNIT_PREFIX, name, hash, ext)
 
 
 class FlotillaDockerService(FlotillaUnit):

--- a/src/flotilla/scheduler/__init__.py
+++ b/src/flotilla/scheduler/__init__.py
@@ -1,6 +1,7 @@
 from .cloudformation import FlotillaCloudFormation
 from .coreos import CoreOsAmiIndex
 from .db import FlotillaSchedulerDynamo
+from .doctor import ServiceDoctor
 from .messaging import FlotillaSchedulerMessaging
 from .provisioner import FlotillaProvisioner
 from .scheduler import FlotillaScheduler

--- a/src/flotilla/scheduler/db.py
+++ b/src/flotilla/scheduler/db.py
@@ -42,12 +42,17 @@ class FlotillaSchedulerDynamo(object):
         """Load revision weights for a particular service.
         :param service_name Service name.
         """
-        try:
-            service = self._services.get_item(service_name=service_name)
-        except ItemNotFound:
+        service = self.get_service(service_name)
+        if not service:
             return {}
         return {k: int(v) for k, v in service.items()
                 if len(k) == REV_LENGTH and v >= 0}
+
+    def get_service(self, service_name):
+        try:
+            return self._services.get_item(service_name=service_name)
+        except ItemNotFound:
+            return None
 
     def services(self):
         for service in self._services.scan(segment=self._segment,
@@ -56,12 +61,6 @@ class FlotillaSchedulerDynamo(object):
 
     def get_stacks(self):
         return [s for s in self._stacks.scan()]
-
-    def get_stack(self, stack_arn):
-        try:
-            return self._stacks.get_item(stack_arn=stack_arn)
-        except ItemNotFound:
-            return None
 
     def set_stacks(self, stacks):
         if not stacks:

--- a/src/flotilla/scheduler/doctor.py
+++ b/src/flotilla/scheduler/doctor.py
@@ -23,7 +23,7 @@ class ServiceDoctor(object):
         if not service_item:
             logger.warn('Service %s not found.', service)
             return
-        if rev not in service_item:
+        if rev not in service_item or service_item[rev] < 0:
             logger.warn('Service %s does not have revision %s.', service, rev)
             return
 

--- a/src/flotilla/scheduler/doctor.py
+++ b/src/flotilla/scheduler/doctor.py
@@ -1,0 +1,92 @@
+import logging
+import time
+
+logger = logging.getLogger('flotilla')
+
+SERVICE_EXPIRY = 10
+
+
+class ServiceDoctor(object):
+    def __init__(self, db, elb):
+        self._db = db
+        self._elb = elb
+
+    def failed_revision(self, service, rev, instance):
+        """
+        Callback when an instance reports it failed to deploy a revision.
+        :param service: Service name.
+        :param rev: Failing revision.
+        :param instance:  Failing instance.
+        :return: None.
+        """
+        service_item = self._db.get_service(service)
+        if not service_item:
+            logger.warn('Service %s not found.', service)
+            return
+
+        logger.info('Diagnosing error of %s in %s on %s...', rev, service,
+                    instance)
+
+        # Are there any instances that _did_ load the service:
+        running = self._running_instances(service, instance, rev)
+        logger.info('Found %s running instances.', len(running))
+        if running:
+            logger.debug('Found %d running instances, verifying ELB health...',
+                         len(running))
+
+            # TODO: not so ELB-centric:
+            healthy = self._healthy_instances(service_item, running)
+            logger.info('Found %s healthy instances.', len(healthy))
+
+            if healthy:
+                logger.info('Diagnosis: %s is broken.', instance)
+                return
+
+        logger.info('Diagnosis: %s is broken', rev)
+        service_item[rev] *= -1
+        self._db.set_services([service_item])
+
+    def _running_instances(self, service, rev, instance):
+        """
+        Return other instances stably running a target revision.
+        :param service: Service name.
+        :param rev: Revision
+        :param instance: Instance id.
+        :return: Running instances.
+        """
+        running_instances = set()
+
+        active_cutoff = time.time() - SERVICE_EXPIRY
+        service_statuses = self._db.get_service_status(service, rev, instance)
+        for instance, services_status in service_statuses:
+            for status in services_status.values():
+                sub_state = status['sub_state']
+                active_time = status['active_enter_time']
+                if sub_state == 'running' and active_time <= active_cutoff:
+                    running_instances.add(instance)
+
+        return running_instances
+
+    def _healthy_instances(self, service_item, running_instances):
+        service_name = service_item['service_name']
+        healthy_instances = set()
+
+        service_outputs = service_item.get('cf_outputs')
+        if not service_outputs:
+            logger.warn('Service %s has no CF outputs', service_name)
+            return healthy_instances
+
+        service_elb = service_outputs.get('Elb')
+        if not service_elb:
+            logger.warn('Service %s has no ELB', service_name)
+            return healthy_instances
+
+        elb_health = self._elb.describe_instance_health(
+                LoadBalancerName=service_elb,
+                Instances=[{'InstanceId': instance_id}
+                           for instance_id in running_instances]
+        )
+        for instance_state in elb_health.get('InstanceStates'):
+            if instance_state['State'] == 'InService':
+                healthy_instances.add(instance_state['InstanceId'])
+        return healthy_instances

--- a/src/flotilla/scheduler/doctor.py
+++ b/src/flotilla/scheduler/doctor.py
@@ -23,6 +23,9 @@ class ServiceDoctor(object):
         if not service_item:
             logger.warn('Service %s not found.', service)
             return
+        if rev not in service_item:
+            logger.warn('Service %s does not have revision %s.', service, rev)
+            return
 
         logger.info('Diagnosing error of %s in %s on %s...', rev, service,
                     instance)

--- a/src/flotilla/scheduler/doctor.py
+++ b/src/flotilla/scheduler/doctor.py
@@ -45,7 +45,7 @@ class ServiceDoctor(object):
                 logger.info('Diagnosis: %s is broken.', instance)
                 return
 
-        logger.info('Diagnosis: %s is broken', rev)
+        logger.info('Diagnosis: %s is broken.', rev)
         service_item[rev] *= -1
         self._db.set_services([service_item])
 

--- a/src/flotilla/scheduler/messaging.py
+++ b/src/flotilla/scheduler/messaging.py
@@ -3,6 +3,9 @@ import logging
 
 logger = logging.getLogger('flotilla')
 
+MESSAGE_RESCHEDULE = 'ServiceReschedule'
+MESSAGE_SERVICE_FAILURE = 'ServiceDidNotStart'
+
 
 class FlotillaSchedulerMessaging(object):
     def __init__(self, messages_q, scheduler, doctor):
@@ -20,11 +23,11 @@ class FlotillaSchedulerMessaging(object):
                 msg.delete()
                 continue
 
-            if msg_type == 'ServiceReschedule':
+            if msg_type == MESSAGE_RESCHEDULE:
                 service = payload['service']
                 logger.debug('Service reschedule: %s', service)
                 self._scheduler.schedule_service(service)
-            elif msg_type == 'ServiceDidNotStart':
+            elif msg_type == MESSAGE_SERVICE_FAILURE:
                 service = payload['service']
                 rev = payload['revision']
                 instance = payload['instance']

--- a/src/flotilla/scheduler/messaging.py
+++ b/src/flotilla/scheduler/messaging.py
@@ -11,9 +11,9 @@ class FlotillaSchedulerMessaging(object):
         self._doctor = doctor
 
     def receive(self):
-        for msg in self._q.get_messages(wait_time_seconds=20):
+        for msg in self._q.receive_messages(WaitTimeSeconds=20):
             try:
-                payload = json.loads(msg.get_body())
+                payload = json.loads(msg.body)
                 msg_type = payload['type']
             except:
                 logger.warn('Invalid message')

--- a/src/flotilla/scheduler/provisioner.py
+++ b/src/flotilla/scheduler/provisioner.py
@@ -21,7 +21,7 @@ class FlotillaProvisioner(object):
         service_stacks = {}
         for service in self._db.services():
             name = service['service_name']
-            services[name] = dict(service)
+            services[name] = service
             if service.get('provision', True):
                 service_stacks[name] = None
 
@@ -59,6 +59,7 @@ class FlotillaProvisioner(object):
             self._db.set_stacks(changed_stacks)
             return
 
+        changed_services = []
         for service_name, service_stack in service_stacks.items():
             service = services[service_name]
 
@@ -68,5 +69,9 @@ class FlotillaProvisioner(object):
                                                              service_stack)
             if new_service_stack:
                 changed_stacks.append(new_service_stack)
-
+                service_outputs = new_service_stack.get('outputs')
+                if service_outputs:
+                    service['cf_outputs'] = service_outputs
+                    changed_services.append(service)
+        self._db.set_services(changed_services)
         self._db.set_stacks(changed_stacks)

--- a/src/flotilla/thread.py
+++ b/src/flotilla/thread.py
@@ -22,8 +22,12 @@ class RepeatingFunc(threading.Thread):
                 self._func()
             except Exception as e:
                 logger.exception(e)
+
             duration = time.time() - start
             interval = self._interval
+            if not interval:
+                logger.debug('Function took %f, repeating.', duration)
+                continue
             if duration > interval:
                 logger.warn('Function took %f, this is too slow for %f.',
                             duration, interval)

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ def setup_logging():
     logging.basicConfig(level=logging.DEBUG,
                         format='%(asctime)s - %(levelname)s - %(threadName)s - %(message)s')
     logging.getLogger('boto').setLevel(logging.CRITICAL)
+    logging.getLogger('botocore').setLevel(logging.CRITICAL)
 
 
 def get_instance_id():

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ def setup_logging():
     logging.basicConfig(level=logging.DEBUG,
                         format='%(asctime)s - %(levelname)s - %(threadName)s - %(message)s')
     logging.getLogger('boto').setLevel(logging.CRITICAL)
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
     logging.getLogger('botocore').setLevel(logging.CRITICAL)
 
 

--- a/src/test/agent/test_agent.py
+++ b/src/test/agent/test_agent.py
@@ -11,7 +11,7 @@ ASSIGNED_REVISION = '00000000000000000000000000000000'
 class TestFlotillaAgent(unittest.TestCase):
     def setUp(self):
         self.db = MagicMock(spec=FlotillaAgentDynamo)
-        self.db.get_assignment.return_value = ASSIGNED_REVISION
+        self.db.get_assignments.return_value = [ASSIGNED_REVISION]
         self.locks = MagicMock(spec=DynamoDbLocks)
         self.systemd = MagicMock(spec=SystemdUnits)
         self.systemd.get_unit_status.return_value = {}
@@ -24,7 +24,7 @@ class TestFlotillaAgent(unittest.TestCase):
         self.db.store_status.assert_called_with(ANY)
 
     def test_assignment_noop(self):
-        self.db.get_assignment.return_value = None
+        self.db.get_assignments.return_value = []
 
         self.agent.assignment()
 
@@ -35,6 +35,7 @@ class TestFlotillaAgent(unittest.TestCase):
 
         self.elb.unregister.assert_called_with()
         self.elb.register.assert_called_with()
+        self.db.get_units.assert_called_with([ASSIGNED_REVISION])
         self.locks.try_lock.assert_called_with('mock-service-deploy')
         self.locks.release_lock.assert_called_with('mock-service-deploy')
         self.systemd.set_units.assert_called_with(ANY)

--- a/src/test/agent/test_agent.py
+++ b/src/test/agent/test_agent.py
@@ -1,7 +1,6 @@
 import unittest
 from mock import MagicMock, ANY
-from flotilla.agent import FlotillaAgent, FlotillaAgentDynamo, LoadBalancer, \
-    SystemdUnits
+from flotilla.agent import *
 from flotilla.db import DynamoDbLocks
 
 SERVICE = 'mock-service'
@@ -16,12 +15,19 @@ class TestFlotillaAgent(unittest.TestCase):
         self.systemd = MagicMock(spec=SystemdUnits)
         self.systemd.get_unit_status.return_value = {}
         self.elb = MagicMock(spec=LoadBalancer)
+        self.messaging = MagicMock(spec=FlotillaAgentMessaging)
         self.agent = FlotillaAgent(SERVICE, self.db, self.locks, self.systemd,
-                                   self.elb)
+                                   self.messaging, self.elb)
 
     def test_health(self):
         self.agent.health()
         self.db.store_status.assert_called_with(ANY)
+        self.messaging.reschedule.assert_called_with()
+
+    def test_health_second(self):
+        self.agent.health()
+        self.agent.health()
+        self.assertEquals(self.messaging.reschedule.call_count, 1)
 
     def test_assignment_noop(self):
         self.db.get_assignments.return_value = []
@@ -39,10 +45,16 @@ class TestFlotillaAgent(unittest.TestCase):
         self.locks.try_lock.assert_called_with('mock-service-deploy')
         self.locks.release_lock.assert_called_with('mock-service-deploy')
         self.systemd.set_units.assert_called_with(ANY)
+        self.messaging.service_failure.assert_not_called()
+
+    def test_assignment_failure(self):
+        self.elb.register.return_value = False
+        self.agent.assignment()
+        self.messaging.service_failure.assert_called_with(ASSIGNED_REVISION)
 
     def test_assignment_elb_safe(self):
         self.agent = FlotillaAgent(SERVICE, self.db, self.locks, self.systemd,
-                                   None)
+                                   self.messaging, None)
 
         self.agent.assignment()
 

--- a/src/test/agent/test_db.py
+++ b/src/test/agent/test_db.py
@@ -7,6 +7,10 @@ from flotilla.agent.db import FlotillaAgentDynamo
 
 ASSIGNED = 'e697b6b7cef7faba1bc7cbd20e0d247fdb46f96231cdef8897de0b6e19468c76'
 
+UNIT_1_HASH = '6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b'
+UNIT_2_HASH = 'd4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35'
+UNIT_3_HASH = '4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce'
+
 
 class TestFlotillaAgentDynamo(unittest.TestCase):
     def setUp(self):
@@ -23,17 +27,21 @@ class TestFlotillaAgentDynamo(unittest.TestCase):
                                       self.status, self.assignments,
                                       self.revisions, self.units, self.kms)
 
-        self.assignments.get_item.side_effect = [{'assignment': ASSIGNED},
-                                                 ItemNotFound()]
-        self.revisions.get_item.return_value = {'units': ['1', '2', '3'],
-                                                'label': 'test'}
+        self.assignments.batch_get.return_value = [{'assignment': ASSIGNED}]
+
+        self.revision = {
+            'units': [UNIT_1_HASH, UNIT_2_HASH, UNIT_3_HASH],
+            'rev_hash': ASSIGNED,
+            'label': 'test'
+        }
+        self.revisions.batch_get.return_value = [self.revision]
         self.units.batch_get.return_value = [
             {'name': '1', 'unit_file': '', 'environment': '',
-             'unit_hash': '6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b'},
+             'unit_hash': UNIT_1_HASH},
             {'name': '2', 'unit_file': '', 'environment': '',
-             'unit_hash': 'd4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35'},
+             'unit_hash': UNIT_2_HASH},
             {'name': '3', 'unit_file': '', 'environment': '',
-             'unit_hash': '4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce'}
+             'unit_hash': UNIT_3_HASH}
         ]
 
     def test_store_status(self):
@@ -44,48 +52,54 @@ class TestFlotillaAgentDynamo(unittest.TestCase):
             other_table.put_item.assert_not_called()
 
     def test_get_assignments(self):
-        assignment = self.db.get_assignment()
+        assignment = self.db.get_assignments()
 
-        self.assertEqual(ASSIGNED, assignment)
+        self.assertEqual([ASSIGNED], assignment)
 
-    def test_get_assignments_none(self):
-        self.assignments.get_item.side_effect = ItemNotFound()
-        assignment = self.db.get_assignment()
-        self.assertEqual(None, assignment)
+        self.assignments.batch_get.assert_called_with([
+            {'instance_id': self.instance_id},
+            {'instance_id': 'global_7'}
 
-    def test_get_units(self):
-        units = self.db.get_units()
-        self.assertEqual(3, len(units))
-        self.revisions.get_item.assert_called_with(rev_hash=ASSIGNED)
-        self.units.batch_get.assert_called_with(keys=[
-            {'unit_hash': '1'},
-            {'unit_hash': '2'},
-            {'unit_hash': '3'}
         ])
 
-    def test_get_units_global(self):
-        self.assignments.get_item.side_effect = [{'assignment': ASSIGNED},
-                                                 {'assignment': ASSIGNED}]
-
-        units = self.db.get_units()
-
-        self.assertEqual(6, len(units))
-
-    def test_load_revision_unit_mismatch(self):
-        self.units.batch_get.return_value = [
-            {'name': '1', 'unit_file': 'pwned', 'environment': '',
-             'unit_hash': '6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b'},
-            {'name': '2', 'unit_file': '', 'environment': '',
-             'unit_hash': 'd4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35'},
-            {'name': '3', 'unit_file': '', 'environment': '',
-             'unit_hash': '4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce'}
+    def test_get_assignments_global(self):
+        self.assignments.batch_get.return_value = [
+            {'assignment': ASSIGNED},
+            {'assignment': ASSIGNED[::-1]}
         ]
 
-        units = self.db._load_revision_units(ASSIGNED)
+        assignment = self.db.get_assignments()
 
+        self.assertEqual(2, len(assignment))
+
+    def test_get_units(self):
+        units = self.db.get_units([ASSIGNED])
         self.assertEqual(3, len(units))
 
-    def test_load_revision_units_decrypt(self):
+        self.revisions.batch_get.assert_called_with([{'rev_hash': ASSIGNED}])
+        self.units.batch_get.assert_called_with([
+            {'unit_hash': UNIT_3_HASH},
+            {'unit_hash': UNIT_1_HASH},
+            {'unit_hash': UNIT_2_HASH}
+        ])
+
+    def test_get_units_hash_mismatch(self):
+        self.units.batch_get.return_value = [
+            {'name': '1', 'unit_file': 'pwned', 'environment': '',
+             'unit_hash': UNIT_1_HASH},
+            {'name': '2', 'unit_file': '', 'environment': '',
+             'unit_hash': UNIT_2_HASH},
+            {'name': '3', 'unit_file': '', 'environment': '',
+             'unit_hash': UNIT_3_HASH}
+        ]
+
+        units = self.db.get_units([ASSIGNED])
+
+        self.assertEquals(3, len(units))
+
+    def test_get_units_decrypt(self):
+        self.revision['units'] = [
+            '2e96c29527f87d9d6a1dbab735590a23132abea196a785f607ec52d1c1a4c730']
         self.units.batch_get.return_value = [{
             'name': '1',
             'unit_file': '',
@@ -94,12 +108,11 @@ class TestFlotillaAgentDynamo(unittest.TestCase):
             'environment_iv': 'MDAwMDAwMDAwMDAwMDAwMA==',
             'environment_data': 'guZyiyEsGQ6e8HIOMRQsdeXMl+6k2ywTfZi+MojMrAg='
         }]
-
         self.kms.decrypt.return_value = {
             'Plaintext': '0000000000000000'
         }
 
-        units = self.db._load_revision_units(ASSIGNED)
+        units = self.db.get_units([ASSIGNED])
 
         self.kms.decrypt.assert_called_with('kms-ciphertext')
         decrypted_env = units[0].environment

--- a/src/test/agent/test_messaging.py
+++ b/src/test/agent/test_messaging.py
@@ -1,0 +1,57 @@
+import unittest
+from mock import MagicMock
+import json
+
+from flotilla.agent.messaging import FlotillaAgentMessaging, \
+    MESSAGE_DEPLOY_LOCK_RELEASED
+
+SERVICE = 'testapp'
+INSTANCE_ID = 'i-123456'
+REVISION = '0000000000000000'
+
+
+class TestFlotillaAgentMessaging(unittest.TestCase):
+    def setUp(self):
+        self.scheduler_q = MagicMock()
+        self.service_q = MagicMock()
+        self.message = MagicMock()
+        self.service_q.receive_messages.return_value = [self.message]
+
+        self.messaging = FlotillaAgentMessaging(SERVICE, INSTANCE_ID,
+                                                self.scheduler_q,
+                                                self.service_q)
+
+    def test_reschedule(self):
+        self.messaging.reschedule()
+        body = '{"type": "ServiceReschedule", "service": "testapp"}'
+        self.scheduler_q.send_message.assert_called_with(MessageBody=body)
+
+    def test_service_failure(self):
+        self.messaging.service_failure(REVISION)
+        body = '{"instance": "i-123456", "type": "ServiceDidNotStart", ' \
+               '"service": "testapp", "revision": "0000000000000000"}'
+        self.scheduler_q.send_message.assert_called_with(MessageBody=body)
+
+    def test_deploy_lock_released(self):
+        self.messaging.deploy_lock_released()
+        body = '{"type": "DeployLockReleased"}'
+        self.service_q.send_message.assert_called_with(MessageBody=body)
+
+    def test_receive_invalid(self):
+        self.message.body = 'not_json'
+        self.messaging.receive()
+        self.message.delete.assert_called_with()
+
+    def test_receive_deploy_lock(self):
+        self.message.body = json.dumps({
+            'type': MESSAGE_DEPLOY_LOCK_RELEASED
+        })
+        self.messaging.receive()
+        self.message.delete.assert_called_with()
+
+    def test_receive_unknown_type(self):
+        self.message.body = json.dumps({
+            'type': 'NotImplemented'
+        })
+        self.messaging.receive()
+        self.message.delete.assert_called_with()

--- a/src/test/cli/test_agent.py
+++ b/src/test/cli/test_agent.py
@@ -1,5 +1,5 @@
 import unittest
-from mock import patch
+from mock import patch, MagicMock
 
 from flotilla.cli.agent import start_agent
 
@@ -10,6 +10,7 @@ ELB = 'elb-1234'
 
 
 class TestAgent(unittest.TestCase):
+    @patch('flotilla.cli.agent.get_queue')
     @patch('flotilla.cli.agent.get_instance_id')
     @patch('flotilla.cli.agent.DynamoDbTables')
     @patch('flotilla.cli.agent.Manager')
@@ -17,8 +18,10 @@ class TestAgent(unittest.TestCase):
     @patch('boto.ec2.elb.connect_to_region')
     @patch('boto.dynamodb2.connect_to_region')
     @patch('boto.kms.connect_to_region')
-    def test_start_agent_no_elb(self, kms, dynamo, elb, repeat, manager,
-                                tables, get_instance_id):
+    @patch('boto3.resource')
+    def test_start_agent_no_elb(self, resource, kms, dynamo, elb, repeat,
+                                manager, tables, get_instance_id, get_queue):
+        get_queue.return_value = None
         get_instance_id.return_value = 'i-123456'
 
         start_agent(ENVIRONMENT, SERVICE, REGION, None, 0.1, 0.1)
@@ -37,10 +40,31 @@ class TestAgent(unittest.TestCase):
     @patch('boto.ec2.elb.connect_to_region')
     @patch('boto.dynamodb2.connect_to_region')
     @patch('boto.kms.connect_to_region')
-    def test_start_agent_elb(self, kms, dynamo, elb, repeat, manager,
+    @patch('boto3.resource')
+    def test_start_agent_elb(self, resource, kms, dynamo, elb, repeat, manager,
                              agent_db, tables, get_instance_id):
         get_instance_id.return_value = 'i-123456'
 
         start_agent(ENVIRONMENT, SERVICE, REGION, ELB, 0.1, 0.1)
 
         elb.assert_called_with(REGION)
+
+    @patch('flotilla.cli.agent.get_queue')
+    @patch('flotilla.cli.agent.get_instance_id')
+    @patch('flotilla.cli.agent.DynamoDbTables')
+    @patch('flotilla.cli.agent.FlotillaAgentDynamo')
+    @patch('flotilla.cli.agent.Manager')
+    @patch('flotilla.cli.agent.RepeatingFunc')
+    @patch('boto.ec2.elb.connect_to_region')
+    @patch('boto.dynamodb2.connect_to_region')
+    @patch('boto.kms.connect_to_region')
+    @patch('boto3.resource')
+    def test_start_agent_messaging(self, resource, kms, dynamo, elb, repeat,
+                                   manager, agent_db, tables, get_instance_id,
+                                   get_queue):
+        get_instance_id.return_value = 'i-123456'
+        get_queue.return_value = MagicMock()
+
+        start_agent(ENVIRONMENT, SERVICE, REGION, ELB, 0.1, 0.1)
+
+        self.assertEquals(3, repeat.call_count)

--- a/src/test/cli/test_region.py
+++ b/src/test/cli/test_region.py
@@ -1,6 +1,7 @@
 import unittest
-from mock import patch
+from mock import patch, MagicMock
 from flotilla.cli.region import configure_region, get_updates
+from flotilla.client.db import FlotillaClientDynamo
 
 ENVIRONMENT = 'develop'
 REGIONS = ('us-east-1', 'us-west-2')
@@ -25,8 +26,6 @@ class TestRegion(unittest.TestCase):
     @patch('flotilla.cli.region.DynamoDbTables')
     @patch('boto.dynamodb2.connect_to_region')
     def test_configure_region(self, dynamo, tables, db):
-        db.check_users.return_value = []
-
         configure_region(ENVIRONMENT, REGIONS, INSTANCE_TYPE, COREOS_CHANNEL,
                          COREOS_VERSION, ADMINS)
 
@@ -36,7 +35,9 @@ class TestRegion(unittest.TestCase):
     @patch('flotilla.cli.region.DynamoDbTables')
     @patch('boto.dynamodb2.connect_to_region')
     def test_configure_region_invalid_admin(self, dynamo, tables, db):
-        db.check_users.return_value = ADMINS
+        mock_db = MagicMock(spec=FlotillaClientDynamo)
+        mock_db.check_users.return_value = ADMINS
+        db.return_value = mock_db
 
         configure_region(ENVIRONMENT, REGIONS, INSTANCE_TYPE, COREOS_CHANNEL,
                          COREOS_VERSION, ADMINS)

--- a/src/test/cli/test_scheduler.py
+++ b/src/test/cli/test_scheduler.py
@@ -3,7 +3,7 @@ from mock import patch, MagicMock
 
 from botocore.exceptions import ClientError
 
-from flotilla.cli.scheduler import start_scheduler, QUEUE_NOT_FOUND
+from flotilla.cli.scheduler import start_scheduler
 
 REGIONS = ['us-east-1']
 ENVIRONMENT = 'develop'
@@ -41,14 +41,13 @@ class TestScheduler(unittest.TestCase):
     @patch('flotilla.cli.scheduler.get_instance_id')
     @patch('flotilla.cli.scheduler.DynamoDbTables')
     @patch('flotilla.cli.scheduler.RepeatingFunc')
+    @patch('flotilla.cli.scheduler.get_queue')
     @patch('boto.dynamodb2.connect_to_region')
     @patch('boto3.resource')
-    def test_start_scheduler_without_messaging(self, sqs, dynamo, repeat,
+    def test_start_scheduler_without_messaging(self, sqs, dynamo, get_queue,
+                                               repeat,
                                                tables, get_instance_id):
-        mock_sqs = MagicMock()
-        client_error = ClientError({'Error': {'Code': QUEUE_NOT_FOUND}}, '')
-        mock_sqs.get_queue_by_name.side_effect = client_error
-        sqs.return_value = mock_sqs
+        get_queue.return_value = None
 
         start_scheduler(ENVIRONMENT, DOMAIN, REGIONS, 0.1, 0.1, 0.1)
 

--- a/src/test/cli/test_utils.py
+++ b/src/test/cli/test_utils.py
@@ -1,0 +1,27 @@
+import unittest
+from mock import MagicMock
+
+from flotilla.cli.utils import get_queue, QUEUE_NOT_FOUND
+from botocore.exceptions import ClientError
+
+QUEUE_NAME = 'test-queue'
+
+
+class TestUtils(unittest.TestCase):
+    def setUp(self):
+        self.sqs = MagicMock()
+
+    def test_get_queue_found(self):
+        queue = get_queue(self.sqs, QUEUE_NAME)
+        self.assertIsNotNone(queue)
+
+    def test_get_queue_not_found(self):
+        client_error = ClientError({'Error': {'Code': QUEUE_NOT_FOUND}}, '')
+        self.sqs.get_queue_by_name.side_effect = client_error
+        queue = get_queue(self.sqs, QUEUE_NAME)
+        self.assertIsNone(queue)
+
+    def test_get_queue_error(self):
+        client_error = ClientError({'Error': {}}, '')
+        self.sqs.get_queue_by_name.side_effect = client_error
+        self.assertRaises(ClientError, get_queue, self.sqs, QUEUE_NAME)

--- a/src/test/client/test_db.py
+++ b/src/test/client/test_db.py
@@ -190,14 +190,14 @@ class TestFlotillaClientDynamo(unittest.TestCase):
         self.assertTrue('environment_iv' in unit)
         self.assertTrue('environment_data' in unit)
 
-    def check_users(self):
+    def test_check_users(self):
         usernames = ['found', 'missing']
         self.users.batch_get.return_value = [
             {'username': 'found'}
         ]
 
         missing_users = self.db.check_users(usernames)
-        self.assertEquals(missing_users, ['missing'])
+        self.assertEquals(missing_users, set(['missing']))
 
     def test_store_revision_encryption(self):
         self.units.has_item.return_value = False

--- a/src/test/client/test_db.py
+++ b/src/test/client/test_db.py
@@ -176,7 +176,7 @@ class TestFlotillaClientDynamo(unittest.TestCase):
 
         self.units.batch_write.assert_called_with()
         self.revisions.new_item.assert_called_with(ANY)
-        self.assignments.put_item.assert_called_with(ANY, overwrite=True)
+        self.assignments.batch_write.assert_called_with()
 
     def test_encrypt_environment(self):
         self.kms.generate_data_key.return_value = {

--- a/src/test/client/test_region_meta.py
+++ b/src/test/client/test_region_meta.py
@@ -1,8 +1,7 @@
 import unittest
 from mock import MagicMock, patch, call, ANY
 from boto.dynamodb2.layer1 import DynamoDBConnection
-from boto.vpc import VPC, VPCConnection
-from boto.exception import BotoServerError
+from botocore.exceptions import ClientError
 
 from flotilla.client.region_meta import RegionMetadata
 
@@ -18,63 +17,66 @@ class TestRegionMetadata(unittest.TestCase):
     def setUp(self):
         self.region_meta = RegionMetadata(ENVIRONMENT)
 
-    @patch('boto.vpc.connect_to_region')
-    def test_create_region_item(self, mock_connect):
+    @patch('boto3.client')
+    def test_region_params(self, mock_connect):
         message = 'Value (us-east-1-zzz) for parameter availabilityZone is ' \
                   'invalid. Subnets can currently only be created in the ' \
                   'following availability zones: us-east-1c, us-east-1a, ' \
                   'us-east-1d, us-east-1e.'
         self.mock_subnet_error(mock_connect, message)
 
-        region_item = self.region_meta._create_region_item(REGION)
+        region_item = self.region_meta._region_params(REGION)
         self.assertEqual(region_item['az1'], 'us-east-1a')
         self.assertEqual(region_item['az2'], 'us-east-1c')
         self.assertEqual(region_item['az3'], 'us-east-1d')
-        self.assertEqual(region_item['region_name'], REGION)
 
-    @patch('boto.vpc.connect_to_region')
-    def test_create_region_item_wrap(self, mock_connect):
+    @patch('boto3.client')
+    def test_region_params_wrap(self, mock_connect):
         message = 'Value (us-east-1-zzz) for parameter availabilityZone is ' \
                   'invalid. Subnets can currently only be created in the ' \
                   'following availability zones: us-east-1c, us-east-1a. '
         self.mock_subnet_error(mock_connect, message)
 
-        region_item = self.region_meta._create_region_item(REGION)
+        region_item = self.region_meta._region_params(REGION)
         self.assertEqual(region_item['az1'], 'us-east-1a')
         self.assertEqual(region_item['az2'], 'us-east-1c')
         self.assertEqual(region_item['az3'], 'us-east-1a')
 
-    @patch('boto.vpc.connect_to_region')
-    def test_create_region_item_exception(self, mock_connect):
-        vpc = MagicMock(spec=VPCConnection)
+    @patch('boto3.client')
+    def test__region_params_exception(self, mock_connect):
+        vpc = MagicMock()
         mock_connect.return_value = vpc
-        vpc.get_all_vpcs.side_effect = BotoServerError(400, 'Kaboom')
+        vpc.describe_vpcs.side_effect = ClientError({'Error': {}}, '')
 
-        self.assertRaises(BotoServerError, self.region_meta._create_region_item,
-                          REGION)
+        self.assertRaises(ClientError, self.region_meta._region_params, REGION)
 
-    @patch('boto.dynamodb2.connect_to_region')
+    @patch('boto3.resource')
     def test_store_regions(self, mock_connect):
-        dynamo = MagicMock(spec=DynamoDBConnection)
+        dynamo = MagicMock()
         mock_connect.return_value = dynamo
-        self.region_meta._create_region_item = lambda x: {'region_name': x}
+        self.region_meta._region_params = MagicMock(return_value={})
+
+        region_params = self.region_meta.store_regions((REGION, REGION_OTHER),
+                                                       False, SCHEDULER,
+                                                       CHANNEL, VERSION)
+        self.assertEquals(mock_connect.call_count, 2)
+
+    @patch('boto3.resource')
+    def test_store_regions_per_region(self, mock_connect):
+        dynamo = MagicMock()
+        mock_connect.return_value = dynamo
+        self.region_meta._region_params = MagicMock(return_value={})
 
         region_params = self.region_meta.store_regions((REGION, REGION_OTHER),
                                                        True, SCHEDULER,
                                                        CHANNEL, VERSION)
-
-        dynamo.batch_write_item.assert_called_with(ANY)
-        region_param = region_params[REGION]
-        self.assertEqual(region_param['scheduler_coreos_channel'], CHANNEL)
-        self.assertEqual(region_param['scheduler_coreos_version'], VERSION)
-        self.assertEqual(region_param['scheduler_instance_type'], SCHEDULER)
+        self.assertEquals(mock_connect.call_count, 2)
 
     def mock_subnet_error(self, mock_connect, message):
-        vpc = MagicMock(spec=VPCConnection)
+        vpc = MagicMock()
         mock_connect.return_value = vpc
-        mock_vpc = MagicMock(spec=VPC)
-        mock_vpc.id = 'vpc-123456'
-        vpc.get_all_vpcs.return_value = [mock_vpc]
-        message = '<Message>%s</Message>' % message
-        vpc.create_subnet.side_effect = BotoServerError(400, 'Bad Request',
-                                                        message)
+        mock_vpc = {'VpcId': 'vpc-123456'}
+        vpc.describe_vpcs.return_value = {'Vpcs': [mock_vpc]}
+
+        client_error = ClientError({'Error': {'Message': message}}, '')
+        vpc.create_subnet.side_effect = client_error

--- a/src/test/db/test_lock.py
+++ b/src/test/db/test_lock.py
@@ -82,3 +82,12 @@ class TestDynamoDbLocks(unittest.TestCase):
 
         locked = self.locks.try_lock(LOCK_NAME, ttl=5)
         self.assertFalse(locked)
+
+    def test_get_owner_found(self):
+        owner, acquire_time = self.locks.get_owner(LOCK_NAME)
+        self.assertEquals(owner, INSTANCE_ID)
+
+    def test_get_owner_not_found(self):
+        self.lock_table.get_item.side_effect = ItemNotFound()
+        owner, acquire_time = self.locks.get_owner(LOCK_NAME)
+        self.assertEquals(owner, None)

--- a/src/test/scheduler/test_db.py
+++ b/src/test/scheduler/test_db.py
@@ -147,15 +147,6 @@ class TestFlotillaSchedulerDynamo(unittest.TestCase):
         self.assertEqual(1, len(stacks))
         self.assertEquals('fred', stacks[0]['service_name'])
 
-    def test_get_stack(self):
-        self.db.get_stack('foo')
-        self.stacks.get_item.assert_called_with(stack_arn='foo')
-
-    def test_get_stack_not_found(self):
-        self.stacks.get_item.side_effect = ItemNotFound()
-        stack = self.db.get_stack('foo')
-        self.assertEqual(stack, None)
-
     def test_set_stacks(self):
         self.db.set_stacks([{'stack_arn': 'foo'}])
         self.stacks.batch_write.assert_called_with()

--- a/src/test/scheduler/test_doctor.py
+++ b/src/test/scheduler/test_doctor.py
@@ -32,6 +32,11 @@ class TestServiceDoctor(unittest.TestCase):
         self.doctor.failed_revision(SERVICE, REV, INSTANCE)
         self.db.set_services.assert_not_called()
 
+    def test_failed_revision_bad_rev(self):
+        self.db.get_service.return_value = None
+        self.doctor.failed_revision(SERVICE, 'abcdef', INSTANCE)
+        self.db.set_services.assert_not_called()
+
     def test_failed_revision_not_running(self):
         # No instances are running this rev
         self.doctor.failed_revision(SERVICE, REV, INSTANCE)

--- a/src/test/scheduler/test_doctor.py
+++ b/src/test/scheduler/test_doctor.py
@@ -33,7 +33,6 @@ class TestServiceDoctor(unittest.TestCase):
         self.db.set_services.assert_not_called()
 
     def test_failed_revision_bad_rev(self):
-        self.db.get_service.return_value = None
         self.doctor.failed_revision(SERVICE, 'abcdef', INSTANCE)
         self.db.set_services.assert_not_called()
 

--- a/src/test/scheduler/test_doctor.py
+++ b/src/test/scheduler/test_doctor.py
@@ -1,0 +1,79 @@
+import unittest
+from mock import MagicMock, ANY
+
+import time
+
+from flotilla.scheduler.db import FlotillaSchedulerDynamo
+from flotilla.scheduler.doctor import ServiceDoctor, SERVICE_EXPIRY
+
+SERVICE = 'testapp'
+REV = '0000000000000000'
+INSTANCE = 'i-123456'
+
+
+class TestServiceDoctor(unittest.TestCase):
+    def setUp(self):
+        self.db = MagicMock(spec=FlotillaSchedulerDynamo)
+        self.elb = MagicMock()
+        self.service = {
+            'service_name': SERVICE,
+            REV: 1,
+            'cf_outputs': {
+                'Elb': 'test-elb',
+                'InstanceSg': 'sg-123456'
+            }
+        }
+        self.db.get_service.return_value = self.service
+
+        self.doctor = ServiceDoctor(self.db, self.elb)
+
+    def test_failed_revision_missing(self):
+        self.db.get_service.return_value = None
+        self.doctor.failed_revision(SERVICE, REV, INSTANCE)
+        self.db.set_services.assert_not_called()
+
+    def test_failed_revision_not_running(self):
+        # No instances are running this rev
+        self.doctor.failed_revision(SERVICE, REV, INSTANCE)
+        self.elb.describe_instance_health.assert_not_called()
+        self.assertEqual(self.service[REV], -1)
+        self.db.set_services.assert_called_with(ANY)
+
+    def test_failed_revision_not_healthy(self):
+        # Instances running, but ELB doesn't have them registered
+        self._mock_service_status()
+        self.doctor.failed_revision(SERVICE, REV, INSTANCE)
+        self.assertEqual(self.service[REV], -1)
+        self.db.set_services.assert_called_with(ANY)
+
+    def test_failed_revision_healthy(self):
+        self._mock_service_status()
+        self.elb.describe_instance_health.return_value = {
+            'InstanceStates': [
+                {'InstanceId': INSTANCE,
+                 'State': 'InService'}
+            ]
+        }
+        self.doctor.failed_revision(SERVICE, REV, INSTANCE)
+        self.assertEqual(self.service[REV], 1)
+        self.db.set_services.assert_not_called()
+
+    def test_healthy_instances_no_outputs(self):
+        del self.service['cf_outputs']
+        healthy = self.doctor._healthy_instances(self.service, [INSTANCE])
+        self.assertEquals(healthy, set())
+
+    def test_healthy_instances_no_elb(self):
+        del self.service['cf_outputs']['Elb']
+        healthy = self.doctor._healthy_instances(self.service, [INSTANCE])
+        self.assertEquals(healthy, set())
+
+    def _mock_service_status(self):
+        self.db.get_service_status.return_value = {
+            'i-654321': {
+                'service-foo': {
+                    'active_enter_time': time.time() - SERVICE_EXPIRY,
+                    'sub_state': 'running'
+                }
+            }
+        }.items()

--- a/src/test/scheduler/test_messaging.py
+++ b/src/test/scheduler/test_messaging.py
@@ -3,7 +3,9 @@ from mock import MagicMock
 import json
 
 from flotilla.scheduler.doctor import ServiceDoctor
-from flotilla.scheduler.messaging import FlotillaSchedulerMessaging
+from flotilla.scheduler.messaging import FlotillaSchedulerMessaging, \
+    MESSAGE_RESCHEDULE, MESSAGE_SERVICE_FAILURE
+
 from flotilla.scheduler.scheduler import FlotillaScheduler
 
 SERVICE = 'test'
@@ -36,7 +38,7 @@ class TestFlotillaSchedulerMessaging(unittest.TestCase):
 
     def test_receive_service_reschedule(self):
         self.message.body = json.dumps({
-            'type': 'ServiceReschedule',
+            'type': MESSAGE_RESCHEDULE,
             'service': SERVICE
         })
 
@@ -47,7 +49,7 @@ class TestFlotillaSchedulerMessaging(unittest.TestCase):
 
     def test_receive_service_did_not_start(self):
         self.message.body = json.dumps({
-            'type': 'ServiceDidNotStart',
+            'type': MESSAGE_SERVICE_FAILURE,
             'service': SERVICE,
             'revision': 'abcdef',
             'instance': 'i-123456',

--- a/src/test/scheduler/test_messaging.py
+++ b/src/test/scheduler/test_messaging.py
@@ -5,6 +5,7 @@ import json
 from boto.sqs.message import Message
 from boto.sqs.queue import Queue
 
+from flotilla.scheduler.doctor import ServiceDoctor
 from flotilla.scheduler.messaging import FlotillaSchedulerMessaging
 from flotilla.scheduler.scheduler import FlotillaScheduler
 
@@ -17,8 +18,10 @@ class TestFlotillaSchedulerMessaging(unittest.TestCase):
         self.message = MagicMock(spec=Message)
         self.queue.get_messages.return_value = [self.message]
         self.scheduler = MagicMock(spec=FlotillaScheduler)
+        self.doctor = MagicMock(spec=ServiceDoctor)
 
-        self.messaging = FlotillaSchedulerMessaging(self.queue, self.scheduler)
+        self.messaging = FlotillaSchedulerMessaging(self.queue, self.scheduler,
+                                                    self.doctor)
 
     def test_receive_empty(self):
         self.queue.get_messages.return_value = []
@@ -48,13 +51,15 @@ class TestFlotillaSchedulerMessaging(unittest.TestCase):
     def test_receive_service_did_not_start(self):
         self.message.get_body.return_value = json.dumps({
             'type': 'ServiceDidNotStart',
+            'service': SERVICE,
+            'revision': 'abcdef',
             'instance': 'i-123456',
-            'revision': 'abcdef'
         })
 
         self.messaging.receive()
 
         self.scheduler.schedule_service.assert_not_called()
+        self.doctor.failed_revision(SERVICE, 'abcdef', 'i-123456')
         self.message.delete.assert_called_with()
 
     def test_receive_unknown_type(self):

--- a/src/test/test_model.py
+++ b/src/test/test_model.py
@@ -34,6 +34,10 @@ class TestFlotillaUnit(unittest.TestCase):
     def test_full_name(self):
         self.assertEqual(self.unit.full_name, UNIT_FULL_NAME)
 
+    def test_full_name_rev_hash(self):
+        self.unit.rev_hash = '000000'
+        self.assertEqual(self.unit.full_name, 'flotilla-test-000000.service')
+
 
 DOCKER_NAME = 'redis'
 DOCKER_IMAGE = 'redis:latest'

--- a/src/test/test_thread.py
+++ b/src/test/test_thread.py
@@ -33,6 +33,15 @@ class TestRepeatingFunc(unittest.TestCase):
         assert self.count > 1
         assert self.count < 3
 
+    def test_run_no_interval(self):
+        instant_function = MagicMock()
+        f = RepeatingFunc('test', instant_function, 0)
+        f.start()
+        time.sleep(0.01)
+        f.stop()
+        f.join()
+        assert instant_function.call_count > 20
+
     def run_loop(self, instant_function):
         f = RepeatingFunc('test', instant_function, 0.01)
         f.start()


### PR DESCRIPTION
When an agent doesn't register with an ELB, it sends a message (SQS) to the scheduler that it can't satisfy the assigned revision.
If no other nodes are running that revision, it's assumed there's something wrong with the revision so it's removed from scheduling (by the scheduler).

Fixes #4  , but needs improvement.