### PR TITLE
Variable AZs

### DIFF
--- a/src/cloudformation/service-elb.template
+++ b/src/cloudformation/service-elb.template
@@ -60,25 +60,9 @@
       "Type": "AWS::EC2::Subnet::Id",
       "Description": "First private subnet."
     },
-    "PrivateSubnet02": {
-      "Type": "AWS::EC2::Subnet::Id",
-      "Description": "Second private subnet."
-    },
-    "PrivateSubnet03": {
-      "Type": "AWS::EC2::Subnet::Id",
-      "Description": "Third private subnet."
-    },
     "PublicSubnet01": {
       "Type": "AWS::EC2::Subnet::Id",
       "Description": "First public subnet."
-    },
-    "PublicSubnet02": {
-      "Type": "AWS::EC2::Subnet::Id",
-      "Description": "Second public subnet."
-    },
-    "PublicSubnet03": {
-      "Type": "AWS::EC2::Subnet::Id",
-      "Description": "Third public subnet."
     },
     "VirtualHost": {
       "Type": "String",
@@ -584,9 +568,7 @@
         "HealthCheckGracePeriod": "600",
         "HealthCheckType": "ELB",
         "VPCZoneIdentifier": [
-          {"Ref": "PrivateSubnet01"},
-          {"Ref": "PrivateSubnet02"},
-          {"Ref": "PrivateSubnet03"}
+          {"Ref": "PrivateSubnet01"}
         ],
         "LaunchConfigurationName": {"Ref": "Lc"},
         "LoadBalancerNames": [
@@ -611,20 +593,6 @@
               "ElbPublic",
               {"Ref": "PublicSubnet01"},
               {"Ref": "PrivateSubnet01"}
-            ]
-          },
-          {
-            "Fn::If": [
-              "ElbPublic",
-              {"Ref": "PublicSubnet02"},
-              {"Ref": "PrivateSubnet02"}
-            ]
-          },
-          {
-            "Fn::If": [
-              "ElbPublic",
-              {"Ref": "PublicSubnet03"},
-              {"Ref": "PrivateSubnet03"}
             ]
           }
         ],

--- a/src/cloudformation/vpc.template
+++ b/src/cloudformation/vpc.template
@@ -21,17 +21,9 @@
       "Default": "pebbletech/flotilla",
       "Description": "Flotilla container version to use."
     },
-    "Az1": {
+    "Az01": {
       "Type": "AWS::EC2::AvailabilityZone::Name",
       "Description": "First AZ."
-    },
-    "Az2": {
-      "Type": "AWS::EC2::AvailabilityZone::Name",
-      "Description": "Second AZ."
-    },
-    "Az3": {
-      "Type": "AWS::EC2::AvailabilityZone::Name",
-      "Description": "Third AZ."
     },
     "NatPerAz": {
       "Description": "Create an NAT gateway in each AZ?",
@@ -88,44 +80,12 @@
       "Properties": {
         "VpcId": {"Ref": "VPC"},
         "CidrBlock": "192.168.1.0/24",
-        "AvailabilityZone": {"Ref": "Az1"},
+        "AvailabilityZone": {"Ref": "Az01"},
         "Tags": [
           {
             "Key": "Name",
             "Value": {
               "Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "Public01"]]
-            }
-          }
-        ]
-      }
-    },
-    "PublicSubnet02": {
-      "Type": "AWS::EC2::Subnet",
-      "Properties": {
-        "VpcId": {"Ref": "VPC"},
-        "CidrBlock": "192.168.2.0/24",
-        "AvailabilityZone": {"Ref": "Az2"},
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": {
-              "Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "Public02"]]
-            }
-          }
-        ]
-      }
-    },
-    "PublicSubnet03": {
-      "Type": "AWS::EC2::Subnet",
-      "Properties": {
-        "VpcId": {"Ref": "VPC"},
-        "CidrBlock": "192.168.3.0/24",
-        "AvailabilityZone": {"Ref": "Az3"},
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": {
-              "Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "Public03"]]
             }
           }
         ]
@@ -162,71 +122,17 @@
         "RouteTableId": {"Ref": "PublicRouteTable"}
       }
     },
-    "PublicSubnet02RouteTableAssociation": {
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-      "Properties": {
-        "SubnetId": {"Ref": "PublicSubnet02"},
-        "RouteTableId": {"Ref": "PublicRouteTable"}
-      }
-    },
-    "PublicSubnet03RouteTableAssociation": {
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-      "Properties": {
-        "SubnetId": {"Ref": "PublicSubnet03"},
-        "RouteTableId": {"Ref": "PublicRouteTable"}
-      }
-    },
     "PrivateSubnet01": {
       "Type": "AWS::EC2::Subnet",
       "Properties": {
         "VpcId": {"Ref": "VPC"},
         "CidrBlock": "192.168.101.0/24",
-        "AvailabilityZone": {"Ref": "Az1"},
+        "AvailabilityZone": {"Ref": "Az01"},
         "Tags": [
           {
             "Key": "Name",
             "Value": {
               "Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "Private01"]]
-            }
-          },
-          {
-            "Key": "Network",
-            "Value": "Private"
-          }
-        ]
-      }
-    },
-    "PrivateSubnet02": {
-      "Type": "AWS::EC2::Subnet",
-      "Properties": {
-        "VpcId": {"Ref": "VPC"},
-        "CidrBlock": "192.168.102.0/24",
-        "AvailabilityZone": {"Ref": "Az2"},
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": {
-              "Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "Private02"]]
-            }
-          },
-          {
-            "Key": "Network",
-            "Value": "Private"
-          }
-        ]
-      }
-    },
-    "PrivateSubnet03": {
-      "Type": "AWS::EC2::Subnet",
-      "Properties": {
-        "VpcId": {"Ref": "VPC"},
-        "CidrBlock": "192.168.103.0/24",
-        "AvailabilityZone": {"Ref": "Az3"},
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": {
-              "Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "Private03"]]
             }
           },
           {
@@ -252,55 +158,11 @@
         ]
       }
     },
-    "PrivateRouteTable02": {
-      "Type": "AWS::EC2::RouteTable",
-      "Properties": {
-        "VpcId": {"Ref": "VPC"},
-        "Tags": [
-          {"Key": "Application", "Value": {"Ref": "AWS::StackName"}},
-          {"Key": "Network", "Value": "Private"},
-          {
-            "Key": "Name", "Value": {
-            "Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "Private02"]]
-          }
-          }
-        ]
-      }
-    },
-    "PrivateRouteTable03": {
-      "Type": "AWS::EC2::RouteTable",
-      "Properties": {
-        "VpcId": {"Ref": "VPC"},
-        "Tags": [
-          {"Key": "Application", "Value": {"Ref": "AWS::StackName"}},
-          {"Key": "Network", "Value": "Private"},
-          {
-            "Key": "Name", "Value": {
-            "Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "Private03"]]
-          }
-          }
-        ]
-      }
-    },
     "PrivateSubnet01RouteTableAssociation": {
       "Type": "AWS::EC2::SubnetRouteTableAssociation",
       "Properties": {
         "SubnetId": {"Ref": "PrivateSubnet01"},
         "RouteTableId": {"Ref": "PrivateRouteTable01"}
-      }
-    },
-    "PrivateSubnet02RouteTableAssociation": {
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-      "Properties": {
-        "SubnetId": {"Ref": "PrivateSubnet02"},
-        "RouteTableId": {"Ref": "PrivateRouteTable02"}
-      }
-    },
-    "PrivateSubnet03RouteTableAssociation": {
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-      "Properties": {
-        "SubnetId": {"Ref": "PrivateSubnet03"},
-        "RouteTableId": {"Ref": "PrivateRouteTable03"}
       }
     },
     "PrivateRouteTable01DefaultRoute": {
@@ -309,30 +171,6 @@
         "RouteTableId": {"Ref": "PrivateRouteTable01"},
         "DestinationCidrBlock": "0.0.0.0/0",
         "NatGatewayId": {"Ref": "NatGateway01"}
-      }
-    },
-    "PrivateRouteTable02DefaultRoute": {
-      "Type": "AWS::EC2::Route",
-      "Properties": {
-        "RouteTableId": {"Ref": "PrivateRouteTable02"},
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId": {
-          "Fn::If": [
-            "MultiAzNat", {"Ref": "NatGateway02"}, {"Ref": "NatGateway01"}
-          ]
-        }
-      }
-    },
-    "PrivateRouteTable03DefaultRoute": {
-      "Type": "AWS::EC2::Route",
-      "Properties": {
-        "RouteTableId": {"Ref": "PrivateRouteTable03"},
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId": {
-          "Fn::If": [
-            "MultiAzNat", {"Ref": "NatGateway03"}, {"Ref": "NatGateway01"}
-          ]
-        }
       }
     },
     "BastionSecurityGroup": {
@@ -538,9 +376,7 @@
         "DesiredCapacity": 1,
         "LaunchConfigurationName": {"Ref": "BastionLC"},
         "VPCZoneIdentifier": [
-          {"Ref": "PublicSubnet01"},
-          {"Ref": "PublicSubnet02"},
-          {"Ref": "PublicSubnet03"}
+          {"Ref": "PublicSubnet01"}
         ],
         "Tags": [
           {
@@ -559,44 +395,12 @@
         "Domain": "vpc"
       }
     },
-    "NatEip02": {
-      "Condition": "MultiAzNat",
-      "Type": "AWS::EC2::EIP",
-      "Properties": {
-        "Domain": "vpc"
-      }
-    },
-    "NatEip03": {
-      "Condition": "MultiAzNat",
-      "Type": "AWS::EC2::EIP",
-      "Properties": {
-        "Domain": "vpc"
-      }
-    },
     "NatGateway01": {
       "DependsOn": "AttachGateway",
       "Type": "AWS::EC2::NatGateway",
       "Properties": {
         "AllocationId": {"Fn::GetAtt": ["NatEip01", "AllocationId"]},
         "SubnetId": {"Ref": "PublicSubnet01"}
-      }
-    },
-    "NatGateway02": {
-      "Condition": "MultiAzNat",
-      "DependsOn": "AttachGateway",
-      "Type": "AWS::EC2::NatGateway",
-      "Properties": {
-        "AllocationId": {"Fn::GetAtt": ["NatEip02", "AllocationId"]},
-        "SubnetId": {"Ref": "PublicSubnet02"}
-      }
-    },
-    "NatGateway03": {
-      "Condition": "MultiAzNat",
-      "DependsOn": "AttachGateway",
-      "Type": "AWS::EC2::NatGateway",
-      "Properties": {
-        "AllocationId": {"Fn::GetAtt": ["NatEip03", "AllocationId"]},
-        "SubnetId": {"Ref": "PublicSubnet03"}
       }
     }
   },
@@ -607,32 +411,14 @@
     "PublicSubnet01": {
       "Value": {"Ref": "PublicSubnet01"}
     },
-    "PublicSubnet02": {
-      "Value": {"Ref": "PublicSubnet02"}
-    },
-    "PublicSubnet03": {
-      "Value": {"Ref": "PublicSubnet03"}
-    },
     "PrivateSubnet01": {
       "Value": {"Ref": "PrivateSubnet01"}
-    },
-    "PrivateSubnet02": {
-      "Value": {"Ref": "PrivateSubnet02"}
-    },
-    "PrivateSubnet03": {
-      "Value": {"Ref": "PrivateSubnet03"}
     },
     "BastionSecurityGroup": {
       "Value": {"Ref": "BastionSecurityGroup"}
     },
     "NatEip01": {
       "Value": {"Ref": "NatEip01"}
-    },
-    "NatEip02": {
-      "Value": {"Fn::If": ["MultiAzNat", {"Ref": "NatEip02"}, ""]}
-    },
-    "NatEip03": {
-      "Value": {"Fn::If": ["MultiAzNat", {"Ref": "NatEip03"}, ""]}
     }
   }
 }

--- a/src/flotilla/client/region_meta.py
+++ b/src/flotilla/client/region_meta.py
@@ -65,7 +65,7 @@ class RegionMetadata(object):
             message_split = message.split(region)
             # Invalid region is echoed back, every mention after that is an AZ:
             azs = sorted([s[0] for s in message_split[2:]])
-            for az_index in range(3):
-                az = az_index % len(azs)
-                region_params['az%d' % (az_index + 1)] = region + azs[az]
+            for index, az in enumerate(azs):
+                region_params['az%d' % (index + 1)] = region + az
+
         return region_params

--- a/src/flotilla/scheduler/cloudformation.py
+++ b/src/flotilla/scheduler/cloudformation.py
@@ -80,12 +80,145 @@ class FlotillaCloudFormation(object):
             return None
         stack_name = 'flotilla-{0}-vpc'.format(self._environment)
 
+        template = self._setup_azs(stack_params, template)
+
         new_stack = self._stack(region_name, stack_name, template, stack_params)
-        stack_outputs = {o.key: o.value for o in new_stack.outputs}
+        stack_outputs = {o.key: o.value for o in new_stack.outputs if o.value}
         return {'stack_arn': new_stack.stack_id,
                 'region': region_name,
                 'outputs': stack_outputs,
                 'stack_hash': stack_hash}
+
+    def _setup_azs(self, stack_params, template):
+        azs = sorted([k for k in stack_params.keys() if k.startswith('Az')])
+
+        json_template = json.loads(template)
+        parameters = json_template['Parameters']
+        resources = json_template['Resources']
+        outputs = json_template['Outputs']
+
+        az_param = parameters['Az01']
+
+        public_subnet = resources['PublicSubnet01']
+        public_rta = resources['PublicSubnet01RouteTableAssociation']
+
+        private_subnet = resources['PrivateSubnet01']
+        private_rt = resources['PrivateRouteTable01']
+        private_default_route = resources['PrivateRouteTable01DefaultRoute']
+        private_rta = resources['PrivateSubnet01RouteTableAssociation']
+
+        nat_gateway = resources['NatGateway01']
+        nat_eip = resources['NatEip01']
+
+        bastion_asg_props = resources['BastionASG']['Properties']
+        bastion_asg_subnets = bastion_asg_props['VPCZoneIdentifier']
+
+        for secondary_az in azs[1:]:
+            az_index = int(secondary_az[2:])
+
+            # Each AZ should be declared as a parameter:
+            parameters[secondary_az] = deepcopy(az_param)
+            parameters[secondary_az]['Description'] = 'Generated AZ parameter.'
+
+            # Each AZ gets a public subnet:
+            public_subnet_resource = 'PublicSubnet%02d' % az_index
+            resources[public_subnet_resource] = self._clone_subnet(
+                    public_subnet,
+                    '192.168.%d.0/24' % az_index,
+                    'Public%02d' % az_index,
+                    secondary_az)
+            outputs[public_subnet_resource] = {
+                'Value': {'Ref': public_subnet_resource}
+            }
+
+            # Public subnets are available for Bastion hosts:
+            bastion_asg_subnets.append({'Ref': public_subnet_resource})
+
+            # Each public subnet is associated with the public route table:
+            public_rta_clone = deepcopy(public_rta)
+            public_rta_props = public_rta_clone['Properties']
+            public_rta_props['SubnetId']['Ref'] = public_subnet_resource
+            public_rta_resource = 'PublicSubnet%02dRouteTableAssociation' % \
+                                  az_index
+            resources[public_rta_resource] = public_rta_clone
+
+            # Each AZ gets a private subnet:
+            private_subnet_resource = 'PrivateSubnet%02d' % az_index
+            resources[private_subnet_resource] = self._clone_subnet(
+                    private_subnet,
+                    '192.168.%d.0/24' % (az_index + 100),
+                    'Private%02d' % az_index,
+                    secondary_az)
+            outputs[private_subnet_resource] = {
+                'Value': {'Ref': private_subnet_resource}
+            }
+
+            # Each AZ gets a private route table:
+            private_rt_clone = deepcopy(private_rt)
+            private_rt_name = self._get_name_tag(private_rt_clone['Properties'])
+            private_rt_name['Fn::Join'][1][1] = 'Private%02d' % az_index
+            private_rt_resource = 'PrivateRouteTable%02d' % az_index
+            resources[private_rt_resource] = private_rt_clone
+
+            # Associate private subnet to route table:
+            private_rta_clone = deepcopy(private_rta)
+            private_rta_props = private_rta_clone['Properties']
+            private_rta_props['SubnetId']['Ref'] = private_subnet_resource
+            private_rta_props['RouteTableId']['Ref'] = private_rt_resource
+            private_rta_resource = 'PrivateSubnet%02dRouteTableAssociation' % \
+                                   az_index
+            resources[private_rta_resource] = private_rta_clone
+
+            # Each AZ _can_ have an ElasticIP for NAT:
+            nat_eip_clone = deepcopy(nat_eip)
+            nat_eip_clone['Condition'] = 'MultiAzNat'
+            nat_eip_resource = 'NatEip%02d' % az_index
+            resources[nat_eip_resource] = nat_eip_clone
+            outputs[nat_eip_resource] = {
+                'Value': {'Fn::If': ['MultiAzNat',
+                                     {'Ref': nat_eip_resource}, '']}
+            }
+
+            # Each AZ _can_ have a NAT gateway:
+            nat_gateway_clone = deepcopy(nat_gateway)
+            nat_gateway_clone['Condition'] = 'MultiAzNat'
+            nat_gateway_props = nat_gateway_clone['Properties']
+            nat_gateway_props['SubnetId']['Ref'] = public_subnet_resource
+            nat_gateway_props['AllocationId']['Fn::GetAtt'][0] = \
+                nat_eip_resource
+            nat_gateway_resource = 'NatGateway%02d' % az_index
+            resources[nat_gateway_resource] = nat_gateway_clone
+
+            # Each private route table has a default NAT route:
+            private_default_route_clone = deepcopy(private_default_route)
+            private_route_props = private_default_route_clone['Properties']
+            private_route_props['RouteTableId']['Ref'] = private_rt_resource
+            private_route_props['NatGatewayId'] = {
+                'Fn::If': [
+                    'MultiAzNat', {'Ref': nat_gateway_resource},
+                    {'Ref': 'NatGateway01'}
+                ]
+            }
+            private_route_resource = 'PrivateRouteTable%02dDefaultRoute' % \
+                                     az_index
+            resources[private_route_resource] = private_default_route_clone
+
+        return json.dumps(json_template, indent=2)
+
+    def _clone_subnet(self, existing_subnet, cidr, label, az):
+        subnet_clone = deepcopy(existing_subnet)
+        subnet_props = subnet_clone['Properties']
+        subnet_props['CidrBlock'] = cidr
+        subnet_props['AvailabilityZone']['Ref'] = az
+        subnet_name = self._get_name_tag(subnet_props)
+        subnet_name['Fn::Join'][1][1] = label
+        return subnet_clone
+
+    @staticmethod
+    def _get_name_tag(resource_props):
+        name_tag = (t for t in resource_props['Tags']
+                    if t['Key'] == 'Name').next()
+        return name_tag['Value']
 
     def _vpc_params(self, region):
         region_name = region.get('region_name')
@@ -95,18 +228,16 @@ class FlotillaCloudFormation(object):
                                            bastion_coreos_version, region_name)
         bastion_instance_type = region.get('bastion_instance_type', 't2.nano')
 
-        az1 = region.get('az1', '%sa' % region_name)
-        az2 = region.get('az2', '%sb' % region_name)
-        az3 = region.get('az3', '%sc' % region_name)
-
         params = {
             'FlotillaEnvironment': self._environment,
             'BastionInstanceType': bastion_instance_type,
-            'BastionAmi': bastion_ami,
-            'Az1': az1,
-            'Az2': az2,
-            'Az3': az3
+            'BastionAmi': bastion_ami
         }
+        az_index = 1
+        for key, value in region.items():
+            if key.startswith('az'):
+                params['Az%02d' % az_index] = value
+                az_index += 1
 
         container = region.get('flotilla_container')
         if container:
@@ -203,7 +334,7 @@ class FlotillaCloudFormation(object):
                                     service_params)
 
         stack_outputs = {o.key: o.value for o in
-                         service_stack.outputs}
+                         service_stack.outputs if o.value}
         stack = {'stack_arn': service_stack.stack_id,
                  'service': service_name,
                  'region': region_name,

--- a/src/test/client/test_region_meta.py
+++ b/src/test/client/test_region_meta.py
@@ -30,6 +30,7 @@ class TestRegionMetadata(unittest.TestCase):
         self.assertEqual(region_item['az1'], 'us-east-1a')
         self.assertEqual(region_item['az2'], 'us-east-1c')
         self.assertEqual(region_item['az3'], 'us-east-1d')
+        self.assertEqual(region_item['az4'], 'us-east-1e')
 
     @patch('boto3.client')
     def test_region_params_wrap(self, mock_connect):
@@ -41,7 +42,7 @@ class TestRegionMetadata(unittest.TestCase):
         region_item = self.region_meta._region_params(REGION)
         self.assertEqual(region_item['az1'], 'us-east-1a')
         self.assertEqual(region_item['az2'], 'us-east-1c')
-        self.assertEqual(region_item['az3'], 'us-east-1a')
+        self.assertNotIn('az3', region_item)
 
     @patch('boto3.client')
     def test__region_params_exception(self, mock_connect):


### PR DESCRIPTION
- RegionMeta is updated to return _every_ available AZ (instead of
  always returning 3).
- vpc.template is updated to only use a single AZ (Az01).
- FlotillaCloudFormation is updated to duplicate per-AZ resources
  according to the N defined AZs.

This horribly breaks deployments to regions with < 3 AZs;
service-elb.template needs the same sort of refactor.
This is just a usable checkpoint.

Fixes #29