### PR TITLE
Revision json

### DIFF
--- a/src/cloudformation/service-elb.template
+++ b/src/cloudformation/service-elb.template
@@ -562,7 +562,6 @@
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
         "Cooldown": "300",
-        "DesiredCapacity": {"Ref": "InstanceMin"},
         "MaxSize": {"Ref": "InstanceMax"},
         "MinSize": {"Ref": "InstanceMin"},
         "HealthCheckGracePeriod": "600",

--- a/src/flotilla/cli/revision.py
+++ b/src/flotilla/cli/revision.py
@@ -2,15 +2,24 @@ import click
 import os.path
 import sys
 import tarfile
+import json
+from time import time, sleep
+import logging
 from io import BytesIO
 import boto.dynamodb2
 import boto.kms
+import boto3
 
 from flotilla.model import FlotillaUnit, FlotillaDockerService, \
     FlotillaServiceRevision
 from flotilla.cli.options import *
+from flotilla.cli.service import parse_private_ports, parse_public_ports
 from flotilla.db.tables import DynamoDbTables
 from flotilla.client.db import FlotillaClientDynamo
+from flotilla.scheduler.db import FlotillaSchedulerDynamo
+from flotilla.scheduler.doctor import ServiceDoctor
+
+logger = logging.getLogger('flotilla')
 
 
 @click.group()
@@ -26,27 +35,65 @@ def revision_cmd():  # pragma: no cover
               help='Regions (multiple allowed).')
 @click.option('--name', type=click.STRING, help='Service name.')
 @click.option('--label', type=click.STRING, help='Revision label.')
-def revision(environment, region, name, label):  # pragma: no cover
-    add_revision(environment, region, name, label, sys.stdin)
+@click.option('--highlander', type=click.INT, default=0,
+              help='Timeout to wait for healthy service, if healthy other revisions are removed. (seconds)')
+@click.option('--env-var', type=click.STRING, multiple=True,
+              help='Environment variable overrides.')
+def revision(environment, region, name, label, highlander,
+             env_var):  # pragma: no cover
+    add_revision(environment, region, name, label, env_var, highlander,
+                 sys.stdin)
 
 
-def add_revision(environment, regions, service_name, label, stream_in):
+SERVICE_UPDATE_KEYS = (
+    'ELB_SCHEME',
+    'DNS_NAME',
+    'HEALTH_CHECK',
+    'INSTANCE_TYPE',
+    'INSTANCE_MIN',
+    'INSTANCE_MAX',
+    'KMS_KEY',
+    'COREOS_CHANNEL',
+    'COREOS_VERSION'
+)
+
+
+def add_revision(environment, regions, service_name, label, env_vars,
+                 highlander, stream_in):
+    # Extract services and files from input:
     files = files_from_tar(stream_in)
-    units = get_units(files)
+    services, environments = get_services_environments(files, environment,
+                                                       env_vars)
 
+    # Extract metadata from environments:
+    service_updates = extract_service_updates(environments.values())
+    env_regions = extract_regions(environments.values())
+    regions = set(regions) | env_regions
+
+    # Build a ServiceRevision with services+enviroment that are left:
+    units = get_units(services, environments)
     service_revision = FlotillaServiceRevision(label, units=units)
 
+    # Add revision and perform updates in each region:
+    dynamo_cache = {}
     for region in regions:
         kms = boto.kms.connect_to_region(region)
 
         dynamo = boto.dynamodb2.connect_to_region(region)
         tables = DynamoDbTables(dynamo, environment=environment)
+        dynamo_cache[region] = tables
 
         tables.setup(['revisions', 'services', 'units'])
         db = FlotillaClientDynamo(None, None, tables.revisions, tables.services,
                                   tables.units, None, kms)
 
         db.add_revision(service_name, service_revision)
+        if service_updates:
+            db.configure_service(service_name, service_updates)
+
+    if highlander > 0:
+        wait_for_deployment(dynamo_cache, regions, service_name,
+                            service_revision.revision_hash, highlander)
 
 
 def files_from_tar(tar_in):
@@ -65,6 +112,26 @@ def files_from_tar(tar_in):
     return tar_contents
 
 
+def get_services_environments(files, environment=None, env_vars=()):
+    services = {}
+    environments = {}
+    for path, contents in files.items():
+        filename = os.path.basename(path)
+        name, extension = os.path.splitext(filename)
+
+        if extension == '.service' and contents:
+            services[name] = contents
+        elif extension == '.env':
+            environments[name] = parse_env(contents)
+        elif extension == '.json':
+            environments[name] = parse_json(contents, environment)
+    for env_var in env_vars:
+        var_key, var_value = env_var.split('=', 1)
+        for environment in environments.values():
+            environment[var_key] = var_value
+    return services, environments
+
+
 def parse_env(contents):
     env = {}
     for line in contents.split('\n'):
@@ -79,25 +146,65 @@ def parse_env(contents):
     return env
 
 
-def get_units(files):
-    services = {}
-    environments = {}
+def parse_json(json_str, environment):
+    body = json.loads(json_str)
+    flotilla_body = body.get('flotilla')
+    if not flotilla_body:
+        flotilla_body = body
 
-    for path, contents in files.items():
-        filename = os.path.basename(path)
-        name, extension = os.path.splitext(filename)
+    defaults = flotilla_body.get('defaults', {})
+    env = flotilla_body.get(environment, {})
+    merged = defaults.copy()
+    merged.update(env)
+    return merged
 
-        if extension == '.service' and contents:
-            services[name] = contents
-        elif extension == '.env':
-            environments[name] = parse_env(contents)
 
+def extract_service_updates(environments):
+    service_updates = {}
+    public_ports = []
+    private_ports = []
+    for environment in environments:
+        for env_key, env_value in environment.items():
+            if env_key in SERVICE_UPDATE_KEYS:
+                service_updates[env_key.lower()] = env_value
+            elif env_key.startswith('PUBLIC_PORT'):
+                public_ports.append(env_value)
+            elif env_key.startswith('PRIVATE_PORT'):
+                private_ports.append(env_value)
+            else:
+                continue
+            del environment[env_key]
+    if public_ports:
+        parsed_ports = parse_public_ports(public_ports)
+        if parsed_ports:
+            service_updates['public_ports'] = parsed_ports
+    if private_ports:
+        parsed_ports = parse_private_ports(private_ports)
+        if parsed_ports:
+            service_updates['private_ports'] = parsed_ports
+    return service_updates
+
+
+def extract_regions(environments):
+    regions = set()
+    for environment in environments:
+        region_val = environment.get('REGION')
+        if region_val:
+            del environment['REGION']
+            env_regions = (isinstance(region_val, str) and
+                           region_val.split(',') or region_val)
+            for region in env_regions:
+                if region:
+                    regions.add(region)
+    return regions
+
+
+def get_units(services, environments):
     units = []
     for name, service in services.items():
         env = environments.get(name, {})
         unit = FlotillaUnit('%s.service' % name, service, env)
         units.append(unit)
-
     for name, env in environments.items():
         if name in services:
             continue
@@ -123,5 +230,50 @@ def get_units(files):
         unit = FlotillaDockerService('%s.service' % name, image, ports=ports,
                                      environment=env, logdriver=logdriver)
         units.append(unit)
-
     return units
+
+
+def wait_for_deployment(dynamo_cache, regions, service_name, rev_hash, timeout):
+    logger.info('Waiting for %s in %s regions...', rev_hash, len(regions))
+
+    # There can be only one!
+    doctor_cache = {}
+    for region in regions:
+        tables = dynamo_cache[region]
+        tables.setup(['status'])
+        db = FlotillaSchedulerDynamo(None, None, tables.services, None,
+                                     tables.status)
+        elb = boto3.client('elb', region)
+        doctor = ServiceDoctor(db, elb)
+        doctor_cache[region] = doctor
+
+    start_time = time()
+    while True:
+        all_healthy = True
+        try:
+            for region, doctor in doctor_cache.items():
+                healthy = doctor.is_healthy_revision(service_name, rev_hash)
+                if not healthy:
+                    all_healthy = False
+                    logger.info('Waiting for %s in %s...', rev_hash, region)
+                    continue
+                logger.info('Region %s has a health %s instance!', region,
+                            rev_hash)
+                doctor.db.make_only_revision(service_name, rev_hash)
+        except ValueError:
+            break
+
+        if all_healthy:
+            logger.info('All regions have a health %s instance!', rev_hash)
+            return True
+        if time() - start_time > timeout:
+            break
+        sleep(5)
+
+    wait_time = time() - start_time
+    logger.info('Revision %s not stable after %s seconds.', rev_hash, wait_time)
+    for region, doctor in doctor_cache.items():
+        service_item = doctor.db.get_service(service_name)
+        if rev_hash in service_item and service_item[rev_hash] > 0:
+            service_item[rev_hash] *= -1
+            doctor.db.set_services([service_item])

--- a/src/flotilla/cli/service.py
+++ b/src/flotilla/cli/service.py
@@ -118,26 +118,36 @@ def get_updates(elb_scheme, dns, health_check, instance_type, provision,
         updates['coreos_version'] = coreos_version
 
     if public_ports:
-        parsed_ports = {}
-        for public_port in public_ports:
-            try:
-                port, proto = public_port.split('-')
-                parsed_ports[int(port)] = proto.upper()
-            except:
-                continue
+        parsed_ports = parse_public_ports(public_ports)
         if parsed_ports:
             updates['public_ports'] = parsed_ports
     if private_ports:
-        parsed_ports = defaultdict(list)
-        for private_port in private_ports:
-            try:
-                port, proto = private_port.split('-')
-                parsed_ports[int(port)].append(proto.upper())
-            except:
-                continue
+        parsed_ports = parse_private_ports(private_ports)
         if parsed_ports:
             updates['private_ports'] = dict(parsed_ports)
     return updates
+
+
+def parse_private_ports(private_ports):
+    parsed_ports = defaultdict(list)
+    for private_port in private_ports:
+        try:
+            port, proto = private_port.split('-')
+            parsed_ports[int(port)].append(proto.upper())
+        except:
+            continue
+    return parsed_ports
+
+
+def parse_public_ports(public_ports):
+    parsed_ports = {}
+    for public_port in public_ports:
+        try:
+            port, proto = public_port.split('-')
+            parsed_ports[int(port)] = proto.upper()
+        except:
+            continue
+    return parsed_ports
 
 
 def configure_service(environment, regions, service_name, updates):

--- a/src/flotilla/scheduler/cloudformation.py
+++ b/src/flotilla/scheduler/cloudformation.py
@@ -286,7 +286,7 @@ class FlotillaCloudFormation(object):
                     'InstancePort': port,
                     'LoadBalancerPort': port,
                     'Protocol': protocol,
-                    'InstanceProtocol': "HTTP"
+                    'InstanceProtocol': protocol
                 })
                 # TODO: support proto=HTTPS
 

--- a/src/flotilla/scheduler/db.py
+++ b/src/flotilla/scheduler/db.py
@@ -156,3 +156,17 @@ class FlotillaSchedulerDynamo(object):
 
             if parsed:
                 yield instance_id, parsed
+
+    def make_only_revision(self, service_name, rev_hash):
+        service = self.get_service(service_name)
+        if not service or rev_hash not in service:
+            return
+
+        changed = False
+        for k, v in service.items():
+            if len(k) == REV_LENGTH and k != rev_hash:
+                del service[k]
+                changed = True
+
+        if changed:
+            service.save()

--- a/src/flotilla/scheduler/doctor.py
+++ b/src/flotilla/scheduler/doctor.py
@@ -6,7 +6,7 @@ logger = logging.getLogger('flotilla')
 
 class ServiceDoctor(object):
     def __init__(self, db, elb):
-        self._db = db
+        self.db = db
         self._elb = elb
 
     def failed_revision(self, service, rev, instance):
@@ -26,7 +26,7 @@ class ServiceDoctor(object):
         if not healthy:
             logger.info('Diagnosis: %s is broken.', rev)
             service_item[rev] *= -1
-            self._db.set_services([service_item])
+            self.db.set_services([service_item])
         else:
             logger.info('Diagnosis: %s is broken.', instance)
 
@@ -47,7 +47,7 @@ class ServiceDoctor(object):
         return self._healthy_instances_with_rev(service_item, rev, None)
 
     def _get_service_with_rev(self, service, rev):
-        service_item = self._db.get_service(service)
+        service_item = self.db.get_service(service)
         if not service_item:
             logger.warn('Service %s not found.', service)
             return None
@@ -82,7 +82,7 @@ class ServiceDoctor(object):
         :return: Running instances.
         """
         running_instances = set()
-        service_statuses = self._db.get_service_status(service, rev, instance)
+        service_statuses = self.db.get_service_status(service, rev, instance)
         for instance, services_status in service_statuses:
             for status in services_status.values():
                 sub_state = status['sub_state']

--- a/src/test/cli/test_revision.py
+++ b/src/test/cli/test_revision.py
@@ -1,11 +1,15 @@
 import unittest
-from mock import MagicMock, patch
+from mock import MagicMock, patch, ANY
 
 from io import BytesIO
 from tarfile import TarFile, TarInfo
+import json
 
 from flotilla.cli.revision import add_revision, files_from_tar, parse_env, \
-    get_units
+    get_units, extract_service_updates, extract_regions, \
+    get_services_environments, wait_for_deployment
+from flotilla.client.db import FlotillaClientDynamo
+from flotilla.scheduler.doctor import ServiceDoctor
 
 ENVIRONMENT = 'test'
 REGIONS = ('us-east-1',)
@@ -54,7 +58,7 @@ BAZ=bing''')
         self.assertEquals(env, {'FOO': 'bar', 'BAZ': 'bing'})
 
     def test_get_units_service(self):
-        units = get_units({'test.service': 'test'})
+        units = get_units({'test': 'test'}, {})
         self.assertEquals(len(units), 1)
         unit = units[0]
         self.assertEquals(unit.name, 'test.service')
@@ -64,8 +68,11 @@ BAZ=bing''')
 
     def test_get_units_environment(self):
         units = get_units({
-            'test.service': 'test',
-            'test.env': 'FOO=bar'
+            'test': 'test',
+        }, {
+            'test': {
+                'FOO': 'bar'
+            }
         })
         self.assertEquals(len(units), 1)
         unit = units[0]
@@ -75,12 +82,12 @@ BAZ=bing''')
                           '77be07ce134644a608226b7906fa20298fab9db9d43e815cda35b4a64be95585')
 
     def test_get_units_docker(self):
-        units = get_units({
-            'test.env': self.env_file({
+        units = get_units({}, {
+            'test': {
                 'DOCKER_IMAGE': 'redis',
                 'DOCKER_PORT_80': 5601,
                 'DOCKER_LOG_DRIVER': 'fluentd'
-            })
+            }
         })
         self.assertEquals(len(units), 1)
         unit = units[0]
@@ -90,32 +97,242 @@ BAZ=bing''')
         self.assertEquals(unit.environment, {})
 
     def test_get_units_env_only(self):
-        units = get_units({'test.env': ''})
+        units = get_units({}, {'test': {}})
         self.assertEquals(len(units), 0)
 
     def test_get_units_docker_invalid_port(self):
-        units = get_units({
-            'test.env': self.env_file({
+        units = get_units({}, {
+            'test': {
                 'DOCKER_IMAGE': 'redis',
                 'DOCKER_PORT_80': 'kaboom',
-            })
+            }
         })
         self.assertEquals(len(units), 1)
         unit = units[0]
         self.assertEquals(unit.environment, {'DOCKER_PORT_80': 'kaboom'})
 
+    def test_get_services_environments_service(self):
+        services, environments = get_services_environments({
+            'test.service': 'test'
+        })
+        self.assertIn('test', services)
+        self.assertEquals(environments, {})
+
+    def test_get_services_environments_env_file(self):
+        services, environments = get_services_environments({
+            'test.env': self.env_file({
+                'MESSAGE': 'hello test'
+            })
+        })
+        self.assertEquals(services, {})
+        unit_env = environments['test']
+        self.assertEquals(unit_env['MESSAGE'], 'hello test')
+
+    def test_get_services_environments_json(self):
+        services, environments = get_services_environments({
+            'test.json': json.dumps({
+                'flotilla': {
+                    'defaults': {
+                        'DOCKER_PORT_6379': 6379,
+                        'DOCKER_IMAGE': 'redis',
+                        'MESSAGE': 'hello default'
+                    },
+                    ENVIRONMENT: {
+                        'MESSAGE': 'hello test'
+                    }
+                }
+            })
+        }, ENVIRONMENT)
+        self.assertEquals(services, {})
+        unit_env = environments['test']
+        self.assertEquals(unit_env['MESSAGE'], 'hello test')
+
+    def test_get_services_environments_json_nowrap(self):
+        _, environments = get_services_environments({
+            'test.json': json.dumps({
+                'defaults': {
+                    'DOCKER_PORT_6379': 6379,
+                    'DOCKER_IMAGE': 'redis',
+                    'MESSAGE': 'hello default'
+                }
+            })
+        }, ENVIRONMENT)
+        self.assertIn('test', environments)
+
+    def test_get_services_environments_type_safe(self):
+        _, environments = get_services_environments({
+            'test.json': json.dumps({
+                'defaults': {
+                    'DOCKER_PORT_6379': 6379,
+                    'DOCKER_IMAGE': 'redis',
+                    'MESSAGE': {
+                        'key': 'abcdef',
+                        'ciphertext': 'defg1234'
+                    }
+                }
+            })
+        }, ENVIRONMENT)
+        unit_env = environments['test']
+        self.assertEquals(unit_env['MESSAGE']['key'], 'abcdef')
+
+    def test_get_services_environments_override(self):
+        _, environments = get_services_environments({
+            'test.json': json.dumps({
+                'defaults': {
+                    'DOCKER_IMAGE': 'redis',
+                    'MESSAGE': 'hello default'
+                }
+            })
+        }, ENVIRONMENT, ['MESSAGE=hello test'])
+        unit_env = environments['test']
+        self.assertEquals(unit_env['MESSAGE'], 'hello test')
+
+    def test_extract_service_updates(self):
+        env = {'INSTANCE_TYPE': 't2.nano',
+               'PUBLIC_PORT_1': '80-http',
+               'PRIVATE_PORT_1': '9300-tcp',
+               'MESSAGE': 'hello test'}
+        updates = extract_service_updates([env])
+        self.assertEquals({'instance_type': 't2.nano',
+                           'public_ports': {80: 'HTTP'},
+                           'private_ports': {9300: ['TCP']}
+                           }, updates)
+        self.assertNotIn('INSTANCE_TYPE', env)
+        self.assertNotIn('PUBLIC_PORT_1', env)
+        self.assertNotIn('PRIVATE_PORT_1', env)
+        self.assertEqual(env['MESSAGE'], 'hello test')
+
+    def test_extract_regions(self):
+        env = {'REGION': 'us-east-1,us-west-2'}
+        regions = extract_regions([env])
+        self.assertEquals(set(('us-east-1', 'us-west-2')), regions)
+        self.assertNotIn('REGION', env)
+
+    def test_extract_type_safe(self):
+        env = {'REGION': ['us-east-1', 'us-west-2']}
+        regions = extract_regions([env])
+        self.assertEquals(set(('us-east-1', 'us-west-2')), regions)
+
+    @patch('flotilla.cli.revision.FlotillaClientDynamo')
     @patch('flotilla.cli.revision.DynamoDbTables')
     @patch('boto.dynamodb2.connect_to_region')
     @patch('boto.kms.connect_to_region')
-    def test_add_revision(self, kms, dynamo, tables):
+    def test_add_revision(self, kms, dynamo, tables, db_factory):
+        db = MagicMock(spec=FlotillaClientDynamo)
+        db_factory.return_value = db
         mock_input = self.generate_tar({
             'test.env': self.env_file({
                 'DOCKER_IMAGE': 'redis'
             })
         })
-        add_revision(ENVIRONMENT, REGIONS, SERVICE, LABEL, mock_input)
+        add_revision(ENVIRONMENT, REGIONS, SERVICE, LABEL, (), 0, mock_input)
 
         self.assertEquals(kms.call_count, len(REGIONS))
+        db.add_revision.assert_called_with(SERVICE, ANY)
+        db.configure_service.assert_not_called()
+
+    @patch('flotilla.cli.revision.FlotillaClientDynamo')
+    @patch('flotilla.cli.revision.DynamoDbTables')
+    @patch('boto.dynamodb2.connect_to_region')
+    @patch('boto.kms.connect_to_region')
+    def test_add_revision_service_update(self, kms, dynamo, tables, db_factory):
+        db = MagicMock(spec=FlotillaClientDynamo)
+        db_factory.return_value = db
+
+        mock_input = self.generate_tar({
+            'test.env': self.env_file({
+                'DOCKER_IMAGE': 'redis',
+                'INSTANCE_TYPE': 't2.nano'
+            })
+        })
+        add_revision(ENVIRONMENT, REGIONS, SERVICE, LABEL, (), 0, mock_input)
+
+        db.configure_service.assert_called_with(SERVICE, ANY)
+
+    @patch('flotilla.cli.revision.wait_for_deployment')
+    @patch('flotilla.cli.revision.DynamoDbTables')
+    @patch('boto.dynamodb2.connect_to_region')
+    @patch('boto.kms.connect_to_region')
+    def test_add_revision_highlander(self, kms, dynamo, tables, wait_for):
+        mock_input = self.generate_tar({
+            'test.env': self.env_file({
+                'DOCKER_IMAGE': 'redis'
+            })
+        })
+        add_revision(ENVIRONMENT, REGIONS, SERVICE, LABEL, (), 30, mock_input)
+
+        wait_for.assert_called_with(ANY, ANY, ANY, ANY, 30)
+
+    @patch('flotilla.cli.revision.ServiceDoctor')
+    @patch('flotilla.cli.revision.boto3')
+    @patch('flotilla.cli.revision.sleep')
+    def test_wait_for_deployment(self, mock_sleep, boto_factory,
+                                 doctor_factory):
+        mock_elb = MagicMock()
+        boto_factory.client.return_value = mock_elb
+        mock_doctor = MagicMock(spec=ServiceDoctor)
+        mock_doctor.db = MagicMock()
+        mock_doctor.is_healthy_revision.side_effect = [
+            False,
+            False,
+            True
+        ]
+        doctor_factory.return_value = mock_doctor
+        dynamo_cache = {region: MagicMock() for region in REGIONS}
+        rev = '000000'
+
+        wait_for_deployment(dynamo_cache, REGIONS, SERVICE, rev, 1)
+
+        self.assertEqual(2, mock_sleep.call_count)
+        mock_doctor.db.make_only_revision.assert_called_with(SERVICE, rev)
+        mock_doctor.db.set_services.assert_not_called()
+
+    @patch('flotilla.cli.revision.ServiceDoctor')
+    @patch('flotilla.cli.revision.boto3')
+    @patch('flotilla.cli.revision.sleep')
+    def test_wait_for_deployment_timeout(self, mock_sleep, boto_factory,
+                                         doctor_factory):
+        rev = '000000'
+        mock_elb = MagicMock()
+        boto_factory.client.return_value = mock_elb
+        mock_doctor = MagicMock(spec=ServiceDoctor)
+        mock_doctor.db = MagicMock()
+        mock_doctor.db.get_service.return_value = {
+            rev: 1
+        }
+        mock_doctor.is_healthy_revision.return_value = False
+        doctor_factory.return_value = mock_doctor
+        dynamo_cache = {region: MagicMock() for region in REGIONS}
+
+        wait_for_deployment(dynamo_cache, REGIONS, SERVICE, rev, 0.001)
+
+        mock_doctor.db.make_only_revision.assert_not_called()
+        mock_doctor.db.set_services.assert_called_with(ANY)
+
+    @patch('flotilla.cli.revision.ServiceDoctor')
+    @patch('flotilla.cli.revision.boto3')
+    @patch('flotilla.cli.revision.sleep')
+    def test_wait_for_deployment_hard_fail(self, mock_sleep, boto_factory,
+                                           doctor_factory):
+        rev = '000000'
+        mock_elb = MagicMock()
+        boto_factory.client.return_value = mock_elb
+        mock_doctor = MagicMock(spec=ServiceDoctor)
+        mock_doctor.db = MagicMock()
+        mock_doctor.db.get_service.return_value = {
+            rev: 1
+        }
+        mock_doctor.is_healthy_revision.side_effect = [
+            False,
+            ValueError('Hard fail')
+        ]
+        doctor_factory.return_value = mock_doctor
+        dynamo_cache = {region: MagicMock() for region in REGIONS}
+
+        wait_for_deployment(dynamo_cache, REGIONS, SERVICE, rev, 0.001)
+
+        mock_doctor.db.make_only_revision.assert_not_called()
+        mock_doctor.db.set_services.assert_called_with(ANY)
 
     @staticmethod
     def generate_tar(entries):

--- a/src/test/test_thread.py
+++ b/src/test/test_thread.py
@@ -40,7 +40,7 @@ class TestRepeatingFunc(unittest.TestCase):
         time.sleep(0.01)
         f.stop()
         f.join()
-        assert instant_function.call_count > 20
+        assert instant_function.call_count > 10
 
     def run_loop(self, instant_function):
         f = RepeatingFunc('test', instant_function, 0.01)


### PR DESCRIPTION
:hand: no merge until cleanups!

This is a big deviation from the existing world of .service's and
.env's.
The JSON format is processed like a .env file: you can specify DOCKER_
members and have a .service file generated.

There's a new feature to add/override .env contents from the command
line. This is for a specific build pipeline feature because I didn't
want to add `jq`.

Additionally .env and .json files can modify 'service' level settings
while registering a 'revision' level change; it just makes sense to keep
INSTANCE_TYPE in the same place as environment variables.
